### PR TITLE
Add comprehensive unit tests with JaCoCo coverage (98.1% line, 88.7% branch)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ plugins {
 subprojects {
 
     apply plugin: "java"
+    apply plugin: "jacoco"
+
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
 
@@ -38,6 +40,47 @@ subprojects {
             url "${project.rootDir}/build/repo"
         }
 
+    }
+
+    jacoco {
+        toolVersion = "0.8.8"
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.enabled true
+            html.enabled true
+        }
+    }
+
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule {
+                limit {
+                    counter = 'LINE'
+                    minimum = 0.95
+                }
+            }
+            rule {
+                limit {
+                    counter = 'BRANCH'
+                    minimum = 0.85
+                }
+            }
+        }
+    }
+
+    test {
+        finalizedBy jacocoTestReport
+        jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+                 '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED'
+    }
+
+    dependencies {
+        testCompile "junit:junit:4.12"
+        testCompile "org.mockito:mockito-core:4.11.0"
+        testCompile "org.mockito:mockito-inline:4.11.0"
+        testCompile "org.assertj:assertj-core:3.24.2"
     }
 
 }

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/AddressTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/AddressTest.java
@@ -1,0 +1,54 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AddressTest {
+
+  @Test
+  public void shouldCreateAddressWithFiveArgs() {
+    Address address = new Address("123 Main", "Apt 4", "Springfield", "IL", "62701");
+    assertThat(address.getStreet1()).isEqualTo("123 Main");
+    assertThat(address.getStreet2()).isEqualTo("Apt 4");
+    assertThat(address.getCity()).isEqualTo("Springfield");
+    assertThat(address.getState()).isEqualTo("IL");
+    assertThat(address.getZip()).isEqualTo("62701");
+    assertThat(address.getLatitude()).isNull();
+    assertThat(address.getLongitude()).isNull();
+  }
+
+  @Test
+  public void shouldCreateAddressWithCoordinates() {
+    Address address = new Address("123 Main", "Apt 4", "Springfield", "IL", "62701", 39.7817, -89.6501);
+    assertThat(address.getLatitude()).isEqualTo(39.7817);
+    assertThat(address.getLongitude()).isEqualTo(-89.6501);
+  }
+
+  @Test
+  public void shouldCreateDefaultAddress() {
+    Address address = new Address();
+    assertThat(address.getStreet1()).isNull();
+    assertThat(address.getCity()).isNull();
+  }
+
+  @Test
+  public void shouldSetAndGetAllFields() {
+    Address address = new Address();
+    address.setStreet1("456 Oak");
+    address.setStreet2("Suite 100");
+    address.setCity("Chicago");
+    address.setState("IL");
+    address.setZip("60601");
+    address.setLatitude(41.8781);
+    address.setLongitude(-87.6298);
+
+    assertThat(address.getStreet1()).isEqualTo("456 Oak");
+    assertThat(address.getStreet2()).isEqualTo("Suite 100");
+    assertThat(address.getCity()).isEqualTo("Chicago");
+    assertThat(address.getState()).isEqualTo("IL");
+    assertThat(address.getZip()).isEqualTo("60601");
+    assertThat(address.getLatitude()).isEqualTo(41.8781);
+    assertThat(address.getLongitude()).isEqualTo(-87.6298);
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/CommonConfigurationTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/CommonConfigurationTest.java
@@ -1,0 +1,23 @@
+package net.chrisrichardson.ftgo.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommonConfigurationTest {
+
+  @Test
+  public void shouldCreateObjectMapperBean() {
+    CommonConfiguration config = new CommonConfiguration();
+    ObjectMapper mapper = config.objectMapper();
+    assertThat(mapper).isNotNull();
+  }
+
+  @Test
+  public void shouldCreateCommonJsonMapperInitializerBean() {
+    CommonConfiguration config = new CommonConfiguration();
+    CommonJsonMapperInitializer initializer = config.commonJsonMapperInitializer();
+    assertThat(initializer).isNotNull();
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/CommonJsonMapperInitializerTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/CommonJsonMapperInitializerTest.java
@@ -1,0 +1,21 @@
+package net.chrisrichardson.ftgo.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommonJsonMapperInitializerTest {
+
+  @Test
+  public void shouldRegisterModulesAndDisableTimestamps() {
+    CommonJsonMapperInitializer initializer = new CommonJsonMapperInitializer();
+    ObjectMapper mapper = new ObjectMapper();
+    ReflectionTestUtils.setField(initializer, "objectMapper", mapper);
+
+    initializer.initialize();
+
+    assertThat(mapper.getRegisteredModuleIds()).isNotEmpty();
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/ErrorResponseTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/ErrorResponseTest.java
@@ -1,0 +1,30 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ErrorResponseTest {
+
+  @Test
+  public void shouldCreateErrorResponseWithAllFields() {
+    ErrorResponse response = new ErrorResponse(404, "Not Found", "Order not found", "/orders/99", "abc-123");
+    assertThat(response.getStatus()).isEqualTo(404);
+    assertThat(response.getError()).isEqualTo("Not Found");
+    assertThat(response.getMessage()).isEqualTo("Order not found");
+    assertThat(response.getPath()).isEqualTo("/orders/99");
+    assertThat(response.getCorrelationId()).isEqualTo("abc-123");
+    assertThat(response.getTimestamp()).isNotNull();
+  }
+
+  @Test
+  public void shouldCreateEmptyErrorResponse() {
+    ErrorResponse response = new ErrorResponse();
+    assertThat(response.getMessage()).isNull();
+    assertThat(response.getStatus()).isEqualTo(0);
+    assertThat(response.getError()).isNull();
+    assertThat(response.getPath()).isNull();
+    assertThat(response.getCorrelationId()).isNull();
+    assertThat(response.getTimestamp()).isNull();
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/MoneyComprehensiveTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/MoneyComprehensiveTest.java
@@ -1,0 +1,111 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MoneyComprehensiveTest {
+
+  @Test
+  public void shouldCreateMoneyFromBigDecimal() {
+    Money money = new Money(new BigDecimal("19.99"));
+    assertThat(money.asString()).isEqualTo("19.99");
+  }
+
+  @Test
+  public void shouldCreateMoneyFromString() {
+    Money money = new Money("25.50");
+    assertThat(money.asString()).isEqualTo("25.50");
+  }
+
+  @Test
+  public void shouldCreateMoneyFromInt() {
+    Money money = new Money(100);
+    assertThat(money.asString()).isEqualTo("100");
+  }
+
+  @Test
+  public void shouldAddMoney() {
+    Money a = new Money("10.00");
+    Money b = new Money("5.50");
+    Money result = a.add(b);
+    assertThat(result.asString()).isEqualTo("15.50");
+  }
+
+  @Test
+  public void shouldMultiplyMoney() {
+    Money money = new Money("3.00");
+    Money result = money.multiply(4);
+    assertThat(result.asString()).isEqualTo("12.00");
+  }
+
+  @Test
+  public void shouldCompareGreaterThanOrEqual() {
+    Money large = new Money("100.00");
+    Money small = new Money("50.00");
+    Money equal = new Money("100.00");
+
+    assertThat(large.isGreaterThanOrEqual(small)).isTrue();
+    assertThat(large.isGreaterThanOrEqual(equal)).isTrue();
+    assertThat(small.isGreaterThanOrEqual(large)).isFalse();
+  }
+
+  @Test
+  public void shouldBeEqualForSameAmount() {
+    Money a = new Money("10.00");
+    Money b = new Money("10.00");
+    assertThat(a).isEqualTo(b);
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
+  @Test
+  public void shouldNotBeEqualForDifferentAmounts() {
+    Money a = new Money("10.00");
+    Money b = new Money("20.00");
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  public void shouldNotEqualNull() {
+    Money money = new Money("10.00");
+    assertThat(money).isNotEqualTo(null);
+  }
+
+  @Test
+  public void shouldNotEqualDifferentType() {
+    Money money = new Money("10.00");
+    assertThat(money.equals("10.00")).isFalse();
+  }
+
+  @Test
+  public void shouldEqualSameReference() {
+    Money money = new Money("10.00");
+    assertThat(money.equals(money)).isTrue();
+  }
+
+  @Test
+  public void shouldHaveToString() {
+    Money money = new Money("42.00");
+    assertThat(money.toString()).contains("42.00");
+  }
+
+  @Test
+  public void zeroShouldHaveZeroAmount() {
+    assertThat(Money.ZERO.asString()).isEqualTo("0");
+  }
+
+  @Test
+  public void shouldAddToZero() {
+    Money result = Money.ZERO.add(new Money("7.50"));
+    assertThat(result.asString()).isEqualTo("7.50");
+  }
+
+  @Test
+  public void shouldMultiplyByZero() {
+    Money money = new Money("10.00");
+    Money result = money.multiply(0);
+    assertThat(result.asString()).isEqualTo("0.00");
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/NotYetImplementedExceptionTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/NotYetImplementedExceptionTest.java
@@ -1,0 +1,21 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NotYetImplementedExceptionTest {
+
+  @Test
+  public void shouldBeRuntimeException() {
+    NotYetImplementedException ex = new NotYetImplementedException();
+    assertThat(ex).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void shouldBeThrowable() {
+    assertThatThrownBy(() -> { throw new NotYetImplementedException(); })
+            .isInstanceOf(NotYetImplementedException.class);
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/PersonNameTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/PersonNameTest.java
@@ -1,0 +1,29 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PersonNameTest {
+
+  @Test
+  public void shouldCreatePersonName() {
+    PersonName name = new PersonName("John", "Doe");
+    assertThat(name.getFirstName()).isEqualTo("John");
+    assertThat(name.getLastName()).isEqualTo("Doe");
+  }
+
+  @Test
+  public void shouldSetFirstName() {
+    PersonName name = new PersonName("John", "Doe");
+    name.setFirstName("Jane");
+    assertThat(name.getFirstName()).isEqualTo("Jane");
+  }
+
+  @Test
+  public void shouldSetLastName() {
+    PersonName name = new PersonName("John", "Doe");
+    name.setLastName("Smith");
+    assertThat(name.getLastName()).isEqualTo("Smith");
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/UnsupportedStateTransitionExceptionTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/UnsupportedStateTransitionExceptionTest.java
@@ -1,0 +1,28 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UnsupportedStateTransitionExceptionTest {
+
+  private enum TestState { ACTIVE, INACTIVE }
+
+  @Test
+  public void shouldContainCurrentStateInMessage() {
+    UnsupportedStateTransitionException ex = new UnsupportedStateTransitionException(TestState.ACTIVE);
+    assertThat(ex.getMessage()).contains("ACTIVE");
+  }
+
+  @Test
+  public void shouldBeRuntimeException() {
+    UnsupportedStateTransitionException ex = new UnsupportedStateTransitionException(TestState.INACTIVE);
+    assertThat(ex).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void shouldContainCurrentStatePrefix() {
+    UnsupportedStateTransitionException ex = new UnsupportedStateTransitionException(TestState.ACTIVE);
+    assertThat(ex.getMessage()).startsWith("current state:");
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogTest.java
@@ -1,0 +1,45 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ApiRequestLogTest {
+
+  @Test
+  public void shouldCreateLogEntry() {
+    ApiRequestLog log = new ApiRequestLog("corr-1", "GET", "/orders", "page=1", "127.0.0.1", "Mozilla/5.0");
+    assertThat(log.getCorrelationId()).isEqualTo("corr-1");
+    assertThat(log.getHttpMethod()).isEqualTo("GET");
+    assertThat(log.getRequestUri()).isEqualTo("/orders");
+    assertThat(log.getQueryString()).isEqualTo("page=1");
+    assertThat(log.getRemoteAddr()).isEqualTo("127.0.0.1");
+    assertThat(log.getUserAgent()).isEqualTo("Mozilla/5.0");
+    assertThat(log.getRequestTimestamp()).isNotNull();
+  }
+
+  @Test
+  public void shouldCompleteSuccessfully() {
+    ApiRequestLog log = new ApiRequestLog("corr-2", "POST", "/orders", null, "10.0.0.1", "curl");
+    log.complete(201, 150L);
+    assertThat(log.getResponseStatus()).isEqualTo(201);
+    assertThat(log.getDurationMs()).isEqualTo(150L);
+    assertThat(log.getErrorMessage()).isNull();
+  }
+
+  @Test
+  public void shouldCompleteWithError() {
+    ApiRequestLog log = new ApiRequestLog("corr-3", "GET", "/orders/999", null, "10.0.0.1", "curl");
+    log.complete(500, 42L, "Internal Server Error");
+    assertThat(log.getResponseStatus()).isEqualTo(500);
+    assertThat(log.getDurationMs()).isEqualTo(42L);
+    assertThat(log.getErrorMessage()).isEqualTo("Internal Server Error");
+  }
+
+  @Test
+  public void shouldCreateDefaultInstance() {
+    ApiRequestLog log = new ApiRequestLog();
+    assertThat(log.getId()).isNull();
+    assertThat(log.getCorrelationId()).isNull();
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfigurationTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfigurationTest.java
@@ -1,0 +1,29 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.junit.Test;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ApiTrackingConfigurationTest {
+
+  @Test
+  public void shouldCreateInterceptorBean() {
+    ApiRequestLogRepository repo = mock(ApiRequestLogRepository.class);
+    ApiTrackingConfiguration config = new ApiTrackingConfiguration(repo);
+
+    ApiTrackingInterceptor interceptor = config.apiTrackingInterceptor();
+    assertThat(interceptor).isNotNull();
+  }
+
+  @Test
+  public void shouldAddInterceptorToRegistry() {
+    ApiRequestLogRepository repo = mock(ApiRequestLogRepository.class);
+    ApiTrackingConfiguration config = new ApiTrackingConfiguration(repo);
+
+    InterceptorRegistry registry = new InterceptorRegistry();
+    config.addInterceptors(registry);
+    // Should not throw
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingControllerTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingControllerTest.java
@@ -1,0 +1,147 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ApiTrackingControllerTest {
+
+  private ApiRequestLogRepository logRepository;
+  private ApiTrackingController controller;
+
+  @Before
+  public void setUp() {
+    logRepository = mock(ApiRequestLogRepository.class);
+    controller = new ApiTrackingController(logRepository);
+  }
+
+  @Test
+  public void shouldGetRecentLogs() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/orders", null, "127.0.0.1", "test");
+    when(logRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Arrays.asList(log1));
+
+    assertThat(controller.getRecentLogs(60).getBody()).hasSize(1);
+  }
+
+  @Test
+  public void shouldGetErrors() {
+    when(logRepository.findErrorsSince(any(LocalDateTime.class))).thenReturn(Collections.emptyList());
+
+    assertThat(controller.getErrors(30).getBody()).isEmpty();
+  }
+
+  @Test
+  public void shouldSearchByUri() {
+    when(logRepository.findByRequestUri("/orders")).thenReturn(Collections.emptyList());
+
+    assertThat(controller.searchByUri("/orders").getBody()).isEmpty();
+  }
+
+  @Test
+  public void shouldGetByCorrelationId() {
+    ApiRequestLog log = new ApiRequestLog("corr-1", "GET", "/test", null, "127.0.0.1", "test");
+    when(logRepository.findByCorrelationId("corr-1")).thenReturn(log);
+
+    assertThat(controller.getByCorrelationId("corr-1").getStatusCodeValue()).isEqualTo(200);
+  }
+
+  @Test
+  public void shouldReturn404ForMissingCorrelationId() {
+    when(logRepository.findByCorrelationId("missing")).thenReturn(null);
+
+    assertThat(controller.getByCorrelationId("missing").getStatusCodeValue()).isEqualTo(404);
+  }
+
+  @Test
+  public void shouldGetStatsWithEmptyLogs() {
+    when(logRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Collections.emptyList());
+
+    Map<String, Object> stats = controller.getStats(60).getBody();
+    assertThat(stats.get("totalRequests")).isEqualTo(0);
+    assertThat(stats.get("periodMinutes")).isEqualTo(60);
+    assertThat(stats.get("errorCount")).isEqualTo(0L);
+    assertThat(stats.get("errorRate")).isEqualTo(0.0);
+  }
+
+  @Test
+  public void shouldGetStatsWithLogs() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/orders", null, "127.0.0.1", "test");
+    log1.complete(200, 100L);
+    ApiRequestLog log2 = new ApiRequestLog("c2", "POST", "/orders", null, "127.0.0.1", "test");
+    log2.complete(500, 200L, "Server Error");
+
+    when(logRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Arrays.asList(log1, log2));
+
+    Map<String, Object> stats = controller.getStats(30).getBody();
+    assertThat(stats.get("totalRequests")).isEqualTo(2);
+    assertThat(stats.get("errorCount")).isEqualTo(1L);
+    assertThat((double) stats.get("errorRate")).isEqualTo(0.5);
+  }
+
+  @Test
+  public void shouldGetStatsWithNullDurationLogs() {
+    ApiRequestLog log = new ApiRequestLog("c1", "GET", "/test", null, "127.0.0.1", "test");
+    // No complete() called, so durationMs is null
+    when(logRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Arrays.asList(log));
+
+    Map<String, Object> stats = controller.getStats(60).getBody();
+    assertThat(stats.get("totalRequests")).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldGetStatsWithNullResponseStatus() {
+    ApiRequestLog log = new ApiRequestLog("c1", "GET", "/test", null, "127.0.0.1", "test");
+    when(logRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Arrays.asList(log));
+
+    Map<String, Object> stats = controller.getStats(60).getBody();
+    assertThat(stats.get("errorCount")).isEqualTo(0L);
+  }
+
+  @Test
+  public void shouldGetStatsWithNullUri() {
+    ApiRequestLog log = new ApiRequestLog("c1", "GET", null, null, "127.0.0.1", "test");
+    log.complete(200, 50L);
+    when(logRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Arrays.asList(log));
+
+    Map<String, Object> stats = controller.getStats(60).getBody();
+    assertThat(stats.get("totalRequests")).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldGetStatsCalculateP95() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/a", null, "127.0.0.1", "test");
+    log1.complete(200, 10L);
+    ApiRequestLog log2 = new ApiRequestLog("c2", "GET", "/b", null, "127.0.0.1", "test");
+    log2.complete(200, 20L);
+    ApiRequestLog log3 = new ApiRequestLog("c3", "GET", "/c", null, "127.0.0.1", "test");
+    log3.complete(200, 500L);
+
+    when(logRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Arrays.asList(log1, log2, log3));
+
+    Map<String, Object> stats = controller.getStats(60).getBody();
+    assertThat((Long) stats.get("p95DurationMs")).isGreaterThanOrEqualTo(0L);
+  }
+
+  @Test
+  public void shouldGetStatsTopEndpoints() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/orders", null, "127.0.0.1", "test");
+    log1.complete(200, 10L);
+    ApiRequestLog log2 = new ApiRequestLog("c2", "GET", "/orders", null, "127.0.0.1", "test");
+    log2.complete(200, 20L);
+
+    when(logRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Arrays.asList(log1, log2));
+
+    Map<String, Object> stats = controller.getStats(60).getBody();
+    @SuppressWarnings("unchecked")
+    Map<String, Long> endpoints = (Map<String, Long>) stats.get("topEndpoints");
+    assertThat(endpoints.get("GET /orders")).isEqualTo(2L);
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptorTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptorTest.java
@@ -1,0 +1,126 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ApiTrackingInterceptorTest {
+
+  private ApiRequestLogRepository logRepository;
+  private ApiTrackingInterceptor interceptor;
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+
+  @Before
+  public void setUp() {
+    logRepository = mock(ApiRequestLogRepository.class);
+    interceptor = new ApiTrackingInterceptor(logRepository);
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+  }
+
+  @Test
+  public void preHandleShouldGenerateCorrelationIdWhenMissing() {
+    when(request.getHeader("X-Correlation-ID")).thenReturn(null);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getRequestURI()).thenReturn("/orders");
+    when(request.getQueryString()).thenReturn(null);
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+    when(request.getHeader("User-Agent")).thenReturn("test");
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertThat(result).isTrue();
+    verify(response).setHeader(eq("X-Correlation-ID"), anyString());
+    verify(request).setAttribute(eq("apiTracking.startTime"), anyLong());
+    verify(request).setAttribute(eq("apiTracking.logEntry"), any(ApiRequestLog.class));
+  }
+
+  @Test
+  public void preHandleShouldUseExistingCorrelationId() {
+    when(request.getHeader("X-Correlation-ID")).thenReturn("existing-id");
+    when(request.getMethod()).thenReturn("POST");
+    when(request.getRequestURI()).thenReturn("/orders");
+    when(request.getQueryString()).thenReturn(null);
+    when(request.getRemoteAddr()).thenReturn("10.0.0.1");
+    when(request.getHeader("User-Agent")).thenReturn("curl");
+
+    interceptor.preHandle(request, response, new Object());
+
+    verify(response).setHeader("X-Correlation-ID", "existing-id");
+  }
+
+  @Test
+  public void afterCompletionShouldPersistLog() {
+    long startTime = System.currentTimeMillis() - 100;
+    ApiRequestLog logEntry = new ApiRequestLog("corr-1", "GET", "/test", null, "127.0.0.1", "test");
+
+    when(request.getAttribute("apiTracking.startTime")).thenReturn(startTime);
+    when(request.getAttribute("apiTracking.logEntry")).thenReturn(logEntry);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getRequestURI()).thenReturn("/test");
+    when(response.getStatus()).thenReturn(200);
+
+    interceptor.afterCompletion(request, response, new Object(), null);
+
+    verify(logRepository).save(logEntry);
+    assertThat(logEntry.getResponseStatus()).isEqualTo(200);
+    assertThat(logEntry.getDurationMs()).isGreaterThanOrEqualTo(0);
+  }
+
+  @Test
+  public void afterCompletionShouldHandleException() {
+    long startTime = System.currentTimeMillis() - 50;
+    ApiRequestLog logEntry = new ApiRequestLog("corr-2", "POST", "/orders", null, "127.0.0.1", "test");
+
+    when(request.getAttribute("apiTracking.startTime")).thenReturn(startTime);
+    when(request.getAttribute("apiTracking.logEntry")).thenReturn(logEntry);
+    when(request.getMethod()).thenReturn("POST");
+    when(request.getRequestURI()).thenReturn("/orders");
+    when(response.getStatus()).thenReturn(500);
+
+    Exception ex = new RuntimeException("something broke");
+    interceptor.afterCompletion(request, response, new Object(), ex);
+
+    verify(logRepository).save(logEntry);
+    assertThat(logEntry.getErrorMessage()).isEqualTo("something broke");
+  }
+
+  @Test
+  public void afterCompletionShouldHandleMissingAttributes() {
+    when(request.getAttribute("apiTracking.startTime")).thenReturn(null);
+    when(request.getAttribute("apiTracking.logEntry")).thenReturn(null);
+
+    interceptor.afterCompletion(request, response, new Object(), null);
+
+    verify(logRepository, never()).save(any());
+  }
+
+  @Test
+  public void afterCompletionShouldHandleSaveFailure() {
+    long startTime = System.currentTimeMillis() - 10;
+    ApiRequestLog logEntry = new ApiRequestLog("corr-3", "GET", "/test", null, "127.0.0.1", "test");
+
+    when(request.getAttribute("apiTracking.startTime")).thenReturn(startTime);
+    when(request.getAttribute("apiTracking.logEntry")).thenReturn(logEntry);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getRequestURI()).thenReturn("/test");
+    when(response.getStatus()).thenReturn(200);
+    doThrow(new RuntimeException("DB error")).when(logRepository).save(any());
+
+    interceptor.afterCompletion(request, response, new Object(), null);
+    // Should not throw
+  }
+
+  @Test
+  public void postHandleShouldDoNothing() {
+    interceptor.postHandle(request, response, new Object(), null);
+    // Just verifying no exceptions
+  }
+}

--- a/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/ConfigurationClassesTest.java
+++ b/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/ConfigurationClassesTest.java
@@ -1,0 +1,29 @@
+package net.chrisrichardson.ftgo.consumerservice;
+
+import net.chrisrichardson.ftgo.consumerservice.domain.ConsumerConfiguration;
+import net.chrisrichardson.ftgo.consumerservice.main.ConsumerServiceConfiguration;
+import net.chrisrichardson.ftgo.consumerservice.web.ConsumerWebConfiguration;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationClassesTest {
+
+  @Test
+  public void shouldInstantiateConsumerWebConfiguration() {
+    ConsumerWebConfiguration config = new ConsumerWebConfiguration();
+    assertThat(config).isNotNull();
+  }
+
+  @Test
+  public void shouldInstantiateConsumerServiceConfiguration() {
+    ConsumerServiceConfiguration config = new ConsumerServiceConfiguration();
+    assertThat(config).isNotNull();
+  }
+
+  @Test
+  public void shouldCreateConsumerServiceBean() {
+    ConsumerConfiguration config = new ConsumerConfiguration();
+    assertThat(config.consumerService()).isNotNull();
+  }
+}

--- a/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/domain/ConsumerServiceTest.java
+++ b/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/domain/ConsumerServiceTest.java
@@ -1,0 +1,77 @@
+package net.chrisrichardson.ftgo.consumerservice.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.domain.Consumer;
+import net.chrisrichardson.ftgo.domain.ConsumerRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class ConsumerServiceTest {
+
+  @Mock
+  private ConsumerRepository consumerRepository;
+
+  @InjectMocks
+  private ConsumerService consumerService;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void shouldCreateConsumer() {
+    PersonName name = new PersonName("Alice", "Jones");
+    Consumer consumer = new Consumer(name);
+    when(consumerRepository.save(any(Consumer.class))).thenReturn(consumer);
+
+    Consumer result = consumerService.create(name);
+    assertThat(result.getName().getFirstName()).isEqualTo("Alice");
+    verify(consumerRepository).save(any(Consumer.class));
+  }
+
+  @Test
+  public void shouldFindConsumerById() {
+    Consumer consumer = new Consumer(new PersonName("Bob", "Smith"));
+    when(consumerRepository.findById(1L)).thenReturn(Optional.of(consumer));
+
+    Optional<Consumer> result = consumerService.findById(1L);
+    assertThat(result).isPresent();
+    assertThat(result.get().getName().getFirstName()).isEqualTo("Bob");
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenConsumerNotFound() {
+    when(consumerRepository.findById(999L)).thenReturn(Optional.empty());
+
+    Optional<Consumer> result = consumerService.findById(999L);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void shouldValidateOrderForConsumer() {
+    Consumer consumer = new Consumer(new PersonName("Test", "User"));
+    when(consumerRepository.findById(1L)).thenReturn(Optional.of(consumer));
+
+    consumerService.validateOrderForConsumer(1L, new Money("50.00"));
+    // should not throw
+  }
+
+  @Test
+  public void shouldThrowWhenConsumerNotFoundForValidation() {
+    when(consumerRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> consumerService.validateOrderForConsumer(999L, new Money("50.00")))
+            .isInstanceOf(ConsumerNotFoundException.class);
+  }
+}

--- a/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/web/ConsumerControllerTest.java
+++ b/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/web/ConsumerControllerTest.java
@@ -1,0 +1,65 @@
+package net.chrisrichardson.ftgo.consumerservice.web;
+
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.consumerservice.api.web.CreateConsumerRequest;
+import net.chrisrichardson.ftgo.consumerservice.api.web.CreateConsumerResponse;
+import net.chrisrichardson.ftgo.consumerservice.domain.ConsumerService;
+import net.chrisrichardson.ftgo.domain.Consumer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ConsumerControllerTest {
+
+  @Mock
+  private ConsumerService consumerService;
+
+  @InjectMocks
+  private ConsumerController controller;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void shouldCreateConsumer() {
+    PersonName name = new PersonName("Alice", "Jones");
+    Consumer consumer = mock(Consumer.class);
+    when(consumer.getId()).thenReturn(42L);
+    when(consumer.getName()).thenReturn(name);
+    when(consumerService.create(any(PersonName.class))).thenReturn(consumer);
+
+    CreateConsumerRequest request = new CreateConsumerRequest(name);
+
+    CreateConsumerResponse response = controller.create(request);
+    assertThat(response).isNotNull();
+    assertThat(response.getConsumerId()).isEqualTo(42L);
+  }
+
+  @Test
+  public void shouldGetConsumerReturns200() {
+    Consumer consumer = new Consumer(new PersonName("Bob", "Smith"));
+    when(consumerService.findById(1L)).thenReturn(Optional.of(consumer));
+
+    ResponseEntity<GetConsumerResponse> response = controller.get(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  public void shouldGetConsumerReturns404WhenNotFound() {
+    when(consumerService.findById(999L)).thenReturn(Optional.empty());
+
+    ResponseEntity<GetConsumerResponse> response = controller.get(999L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+}

--- a/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/web/GetConsumerResponseTest.java
+++ b/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/web/GetConsumerResponseTest.java
@@ -1,0 +1,17 @@
+package net.chrisrichardson.ftgo.consumerservice.web;
+
+import net.chrisrichardson.ftgo.common.PersonName;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GetConsumerResponseTest {
+
+  @Test
+  public void shouldCreateWithName() {
+    PersonName name = new PersonName("Alice", "Jones");
+    GetConsumerResponse response = new GetConsumerResponse(name);
+    assertThat(response.getName().getFirstName()).isEqualTo("Alice");
+    assertThat(response.getName().getLastName()).isEqualTo("Jones");
+  }
+}

--- a/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/ConfigurationClassesTest.java
+++ b/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/ConfigurationClassesTest.java
@@ -1,0 +1,25 @@
+package net.chrisrichardson.ftgo.courierservice;
+
+import net.chrisrichardson.ftgo.courierservice.domain.CourierServiceConfiguration;
+import net.chrisrichardson.ftgo.courierservice.web.CourierWebConfiguration;
+import net.chrisrichardson.ftgo.domain.CourierRepository;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class ConfigurationClassesTest {
+
+  @Test
+  public void shouldCreateCourierServiceBean() {
+    CourierServiceConfiguration config = new CourierServiceConfiguration();
+    CourierRepository repo = mock(CourierRepository.class);
+    assertThat(config.courierService(repo)).isNotNull();
+  }
+
+  @Test
+  public void shouldInstantiateCourierWebConfiguration() {
+    CourierWebConfiguration config = new CourierWebConfiguration();
+    assertThat(config).isNotNull();
+  }
+}

--- a/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/domain/CourierServiceTest.java
+++ b/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/domain/CourierServiceTest.java
@@ -1,0 +1,84 @@
+package net.chrisrichardson.ftgo.courierservice.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.domain.Courier;
+import net.chrisrichardson.ftgo.domain.CourierRepository;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class CourierServiceTest {
+
+  private CourierRepository courierRepository;
+  private CourierService courierService;
+
+  @Before
+  public void setUp() {
+    courierRepository = mock(CourierRepository.class);
+    courierService = new CourierService(courierRepository);
+  }
+
+  @Test
+  public void shouldCreateCourier() {
+    PersonName name = new PersonName("John", "Doe");
+    Address address = new Address("1 Main St", null, "NYC", "NY", "10001");
+    Courier courier = new Courier(name, address);
+    when(courierRepository.save(any(Courier.class))).thenReturn(courier);
+
+    Courier result = courierService.createCourier(name, address);
+    assertThat(result.getName().getFirstName()).isEqualTo("John");
+    verify(courierRepository).save(any(Courier.class));
+  }
+
+  @Test
+  public void shouldUpdateAvailabilityToAvailable() {
+    Courier courier = new Courier(new PersonName("A", "B"), new Address("1", null, "C", "S", "Z"));
+    when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
+
+    courierService.updateAvailability(1L, true);
+    assertThat(courier.isAvailable()).isTrue();
+  }
+
+  @Test
+  public void shouldUpdateAvailabilityToUnavailable() {
+    Courier courier = new Courier(new PersonName("A", "B"), new Address("1", null, "C", "S", "Z"));
+    courier.noteAvailable();
+    when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
+
+    courierService.updateAvailability(1L, false);
+    assertThat(courier.isAvailable()).isFalse();
+  }
+
+  @Test
+  public void shouldFindCourierById() {
+    Courier courier = new Courier(new PersonName("X", "Y"), new Address("1", null, "C", "S", "Z"));
+    when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
+
+    Courier result = courierService.findCourierById(1L);
+    assertThat(result).isEqualTo(courier);
+  }
+
+  @Test
+  public void shouldUpdateLocation() {
+    Courier courier = new Courier(new PersonName("A", "B"), new Address("1", null, "C", "S", "Z"));
+    when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
+
+    courierService.updateLocation(1L, 40.7, -74.0);
+    assertThat(courier.getCurrentLatitude()).isEqualTo(40.7);
+    assertThat(courier.getCurrentLongitude()).isEqualTo(-74.0);
+  }
+
+  @Test
+  public void shouldThrowWhenUpdatingLocationForNonExistentCourier() {
+    when(courierRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> courierService.updateLocation(999L, 40.7, -74.0))
+            .isInstanceOf(CourierNotFoundException.class);
+  }
+}

--- a/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/web/CourierControllerTest.java
+++ b/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/web/CourierControllerTest.java
@@ -1,0 +1,93 @@
+package net.chrisrichardson.ftgo.courierservice.web;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.courierservice.api.CourierAvailability;
+import net.chrisrichardson.ftgo.courierservice.api.CourierLocationUpdate;
+import net.chrisrichardson.ftgo.courierservice.api.CourierWorkloadResponse;
+import net.chrisrichardson.ftgo.courierservice.api.CreateCourierRequest;
+import net.chrisrichardson.ftgo.courierservice.api.CreateCourierResponse;
+import net.chrisrichardson.ftgo.courierservice.domain.CourierService;
+import net.chrisrichardson.ftgo.domain.Courier;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class CourierControllerTest {
+
+  private CourierService courierService;
+  private CourierController controller;
+
+  @Before
+  public void setUp() {
+    courierService = mock(CourierService.class);
+    controller = new CourierController(courierService);
+  }
+
+  @Test
+  public void shouldCreateCourier() {
+    Courier courier = mock(Courier.class);
+    when(courier.getId()).thenReturn(1L);
+    when(courierService.createCourier(any(PersonName.class), any(Address.class))).thenReturn(courier);
+
+    CreateCourierRequest request = new CreateCourierRequest();
+    request.setName(new PersonName("J", "D"));
+    request.setAddress(new Address("1", null, "C", "S", "Z"));
+
+    ResponseEntity<CreateCourierResponse> response = controller.create(request);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getId()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldUpdateAvailability() {
+    CourierAvailability availability = new CourierAvailability();
+    availability.setAvailable(true);
+
+    ResponseEntity<String> response = controller.updateCourierLocation(1L, availability);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(courierService).updateAvailability(1L, true);
+  }
+
+  @Test
+  public void shouldGetCourier() {
+    Courier courier = new Courier(new PersonName("J", "D"), new Address("1", null, "C", "S", "Z"));
+    when(courierService.findCourierById(1L)).thenReturn(courier);
+
+    ResponseEntity<Courier> response = controller.get(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo(courier);
+  }
+
+  @Test
+  public void shouldUpdateLocation() {
+    CourierLocationUpdate locationUpdate = new CourierLocationUpdate();
+    locationUpdate.setLatitude(40.7);
+    locationUpdate.setLongitude(-74.0);
+
+    ResponseEntity<String> response = controller.updateLocation(1L, locationUpdate);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(courierService).updateLocation(1L, 40.7, -74.0);
+  }
+
+  @Test
+  public void shouldGetWorkload() {
+    Courier courier = mock(Courier.class);
+    when(courier.getId()).thenReturn(1L);
+    when(courier.getActiveDeliveryCount()).thenReturn(2);
+    when(courier.isAvailable()).thenReturn(true);
+    when(courier.getCurrentLatitude()).thenReturn(40.7);
+    when(courier.getCurrentLongitude()).thenReturn(-74.0);
+    when(courier.getLastLocationUpdate()).thenReturn(null);
+    when(courierService.findCourierById(1L)).thenReturn(courier);
+
+    ResponseEntity<CourierWorkloadResponse> response = controller.getWorkload(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().isAvailable()).isTrue();
+    assertThat(response.getBody().getActiveDeliveries()).isEqualTo(2);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/ActionTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/ActionTest.java
@@ -1,0 +1,68 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ActionTest {
+
+  private Order order;
+
+  @Before
+  public void setUp() {
+    Restaurant restaurant = new Restaurant("R", new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("i1", "Item", new Money("10.00")))));
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("i1", "Item", new Money("10.00"), 1));
+    order = new Order(1L, restaurant, items);
+    order.setId(1L);
+  }
+
+  @Test
+  public void shouldMakePickupAction() {
+    Action action = Action.makePickup(order);
+    assertThat(action.getType()).isEqualTo(ActionType.PICKUP);
+    assertThat(action.getTime()).isNull();
+  }
+
+  @Test
+  public void shouldMakeDropoffAction() {
+    LocalDateTime deliveryTime = LocalDateTime.now().plusHours(1);
+    Action action = Action.makeDropoff(order, deliveryTime);
+    assertThat(action.getType()).isEqualTo(ActionType.DROPOFF);
+    assertThat(action.getTime()).isEqualTo(deliveryTime);
+  }
+
+  @Test
+  public void shouldMatchActionForSameOrder() {
+    Action action = Action.makePickup(order);
+    assertThat(action.actionFor(order)).isTrue();
+  }
+
+  @Test
+  public void shouldNotMatchActionForDifferentOrder() {
+    Action action = Action.makePickup(order);
+
+    Restaurant restaurant2 = new Restaurant("R2", new Address("2", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("i2", "Item2", new Money("5.00")))));
+    List<OrderLineItem> items2 = Arrays.asList(new OrderLineItem("i2", "Item2", new Money("5.00"), 1));
+    Order order2 = new Order(2L, restaurant2, items2);
+    order2.setId(2L);
+
+    assertThat(action.actionFor(order2)).isFalse();
+  }
+
+  @Test
+  public void shouldCreateWithConstructor() {
+    LocalDateTime time = LocalDateTime.now();
+    Action action = new Action(ActionType.PICKUP, order, time);
+    assertThat(action.getType()).isEqualTo(ActionType.PICKUP);
+    assertThat(action.getTime()).isEqualTo(time);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/ConsumerTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/ConsumerTest.java
@@ -1,0 +1,30 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConsumerTest {
+
+  @Test
+  public void shouldCreateConsumer() {
+    Consumer consumer = new Consumer(new PersonName("Alice", "Johnson"));
+    assertThat(consumer.getName().getFirstName()).isEqualTo("Alice");
+    assertThat(consumer.getName().getLastName()).isEqualTo("Johnson");
+  }
+
+  @Test
+  public void shouldValidateOrderByConsumer() {
+    Consumer consumer = new Consumer(new PersonName("Bob", "Smith"));
+    // Should not throw - the method is a no-op placeholder
+    consumer.validateOrderByConsumer(new Money("100.00"));
+  }
+
+  @Test
+  public void shouldGetId() {
+    Consumer consumer = new Consumer(new PersonName("Test", "User"));
+    assertThat(consumer.getId()).isNull();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/CourierTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/CourierTest.java
@@ -1,0 +1,155 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CourierTest {
+
+  private Courier courier;
+
+  @Before
+  public void setUp() {
+    courier = new Courier(new PersonName("Jane", "Smith"),
+            new Address("10 Park Ave", null, "NYC", "NY", "10001", 40.7128, -74.0060));
+  }
+
+  @Test
+  public void shouldCreateCourierWithLocationFromAddress() {
+    assertThat(courier.getCurrentLatitude()).isEqualTo(40.7128);
+    assertThat(courier.getCurrentLongitude()).isEqualTo(-74.0060);
+    assertThat(courier.getName().getFirstName()).isEqualTo("Jane");
+    assertThat(courier.getName().getLastName()).isEqualTo("Smith");
+  }
+
+  @Test
+  public void shouldCreateCourierWithAddressWithoutCoordinates() {
+    Courier c = new Courier(new PersonName("Bob", "Jones"),
+            new Address("5 Elm St", null, "LA", "CA", "90001"));
+    assertThat(c.getCurrentLatitude()).isNull();
+    assertThat(c.getCurrentLongitude()).isNull();
+  }
+
+  @Test
+  public void shouldCreateCourierWithNullAddress() {
+    Courier c = new Courier(new PersonName("Alice", "Wonder"), null);
+    assertThat(c.getAddress()).isNull();
+    assertThat(c.getCurrentLatitude()).isNull();
+  }
+
+  @Test
+  public void shouldNoteAvailable() {
+    courier.noteAvailable();
+    assertThat(courier.isAvailable()).isTrue();
+  }
+
+  @Test
+  public void shouldNoteUnavailable() {
+    courier.noteAvailable();
+    courier.noteUnavailable();
+    assertThat(courier.isAvailable()).isFalse();
+  }
+
+  @Test
+  public void shouldNotBeAvailableByDefault() {
+    Courier c = new Courier();
+    assertThat(c.isAvailable()).isFalse();
+  }
+
+  @Test
+  public void shouldUpdateLocation() {
+    courier.updateLocation(41.0, -73.5);
+    assertThat(courier.getCurrentLatitude()).isEqualTo(41.0);
+    assertThat(courier.getCurrentLongitude()).isEqualTo(-73.5);
+    assertThat(courier.getLastLocationUpdate()).isNotNull();
+  }
+
+  @Test
+  public void shouldHaveLocationWhenBothCoordsSet() {
+    assertThat(courier.hasLocation()).isTrue();
+  }
+
+  @Test
+  public void shouldNotHaveLocationWhenNullCoords() {
+    Courier c = new Courier(new PersonName("X", "Y"), new Address("1", null, "C", "S", "Z"));
+    assertThat(c.hasLocation()).isFalse();
+  }
+
+  @Test
+  public void shouldAddAction() {
+    Restaurant restaurant = new Restaurant("R", new Address("1", null, "C", "S", "Z"), new RestaurantMenu(Arrays.asList(new MenuItem("i1", "Pizza", new Money("12.00")))));
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("i1", "Pizza", new Money("12.00"), 1));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(100L);
+
+    courier.addAction(Action.makePickup(order));
+    assertThat(courier.getPlan().getActions()).hasSize(1);
+  }
+
+  @Test
+  public void shouldCancelDelivery() {
+    Restaurant restaurant = new Restaurant("R", new Address("1", null, "C", "S", "Z"), new RestaurantMenu(Arrays.asList(new MenuItem("i1", "Pizza", new Money("12.00")))));
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("i1", "Pizza", new Money("12.00"), 1));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(100L);
+
+    courier.addAction(Action.makePickup(order));
+    courier.addAction(Action.makeDropoff(order, LocalDateTime.now().plusHours(1)));
+    assertThat(courier.getPlan().getActions()).hasSize(2);
+
+    courier.cancelDelivery(order);
+    assertThat(courier.getPlan().getActions()).isEmpty();
+  }
+
+  @Test
+  public void shouldGetActionsForDelivery() {
+    Restaurant restaurant = new Restaurant("R", new Address("1", null, "C", "S", "Z"), new RestaurantMenu(Arrays.asList(new MenuItem("i1", "Pizza", new Money("12.00")))));
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("i1", "Pizza", new Money("12.00"), 1));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(100L);
+
+    courier.addAction(Action.makePickup(order));
+    courier.addAction(Action.makeDropoff(order, LocalDateTime.now().plusHours(1)));
+
+    List<Action> actions = courier.actionsForDelivery(order);
+    assertThat(actions).hasSize(2);
+  }
+
+  @Test
+  public void shouldGetActiveDeliveryCount() {
+    assertThat(courier.getActiveDeliveryCount()).isEqualTo(0);
+
+    Restaurant restaurant = new Restaurant("R", new Address("1", null, "C", "S", "Z"), new RestaurantMenu(Arrays.asList(new MenuItem("i1", "Pizza", new Money("12.00")))));
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("i1", "Pizza", new Money("12.00"), 1));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(100L);
+
+    courier.addAction(Action.makePickup(order));
+    assertThat(courier.getActiveDeliveryCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldGetAddress() {
+    assertThat(courier.getAddress()).isNotNull();
+    assertThat(courier.getAddress().getCity()).isEqualTo("NYC");
+  }
+
+  @Test
+  public void shouldGetId() {
+    assertThat(courier.getId()).isNull();
+  }
+
+  @Test
+  public void shouldGetLastLocationUpdateInitiallyNull() {
+    Courier c = new Courier(new PersonName("A", "B"), new Address("1", null, "C", "S", "Z", 1.0, 2.0));
+    assertThat(c.getLastLocationUpdate()).isNull();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/DeliveryInformationTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/DeliveryInformationTest.java
@@ -1,0 +1,17 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeliveryInformationTest {
+
+  @Test
+  public void shouldCreateDefaultDeliveryInformation() {
+    DeliveryInformation di = new DeliveryInformation();
+    assertThat(di).isNotNull();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/DistanceOptimizedCourierAssignmentStrategyTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/DistanceOptimizedCourierAssignmentStrategyTest.java
@@ -1,0 +1,158 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class DistanceOptimizedCourierAssignmentStrategyTest {
+
+  private DistanceOptimizedCourierAssignmentStrategy strategy;
+
+  @Before
+  public void setUp() {
+    strategy = new DistanceOptimizedCourierAssignmentStrategy();
+  }
+
+  @Test
+  public void shouldThrowWhenNoCouriersAvailable() {
+    Order order = makeOrder(40.7128, -74.0060);
+    assertThatThrownBy(() -> strategy.assignCourier(Collections.emptyList(), order))
+            .isInstanceOf(NoCourierAvailableException.class);
+  }
+
+  @Test
+  public void shouldAssignClosestCourier() {
+    Order order = makeOrder(40.7128, -74.0060);
+
+    Courier close = makeCourier(40.7130, -74.0062);
+    close.noteAvailable();
+    Courier far = makeCourier(40.8000, -73.9000);
+    far.noteAvailable();
+
+    Courier assigned = strategy.assignCourier(Arrays.asList(far, close), order);
+    assertThat(assigned).isEqualTo(close);
+  }
+
+  @Test
+  public void shouldFallbackToLoadBalanceWhenNoRestaurantLocation() {
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(new MenuItem("i1", "Item", new Money("10.00"))));
+    Restaurant restaurant = new Restaurant("R", new Address("1", null, "C", "S", "Z"), menu);
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("i1", "Item", new Money("10.00"), 1));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(1L);
+
+    Courier c1 = makeCourier(40.0, -74.0);
+    c1.noteAvailable();
+    Courier c2 = makeCourier(41.0, -73.0);
+    c2.noteAvailable();
+
+    Courier assigned = strategy.assignCourier(Arrays.asList(c1, c2), order);
+    assertThat(assigned).isNotNull();
+  }
+
+  @Test
+  public void shouldSkipCouriersAtMaxCapacity() {
+    Order order = makeOrder(40.7128, -74.0060);
+
+    Courier overloaded = makeCourier(40.7129, -74.0061);
+    overloaded.noteAvailable();
+    // Add 5 pickups to max out
+    for (int i = 0; i < 5; i++) {
+      Order o = makeOrder(40.0 + i * 0.01, -74.0);
+      o.setId((long)(i + 10));
+      overloaded.addAction(Action.makePickup(o));
+    }
+
+    Courier available = makeCourier(40.8000, -73.9000);
+    available.noteAvailable();
+
+    Courier assigned = strategy.assignCourier(Arrays.asList(overloaded, available), order);
+    assertThat(assigned).isEqualTo(available);
+  }
+
+  @Test
+  public void shouldAssignByLoadBalanceWhenAllMaxed() {
+    Order order = makeOrder(40.7128, -74.0060);
+
+    Courier c1 = makeCourier(40.7129, -74.0061);
+    c1.noteAvailable();
+    for (int i = 0; i < 5; i++) {
+      Order o = makeOrder(40.0 + i * 0.01, -74.0);
+      o.setId((long)(i + 10));
+      c1.addAction(Action.makePickup(o));
+    }
+
+    Courier c2 = makeCourier(40.7200, -74.0100);
+    c2.noteAvailable();
+    for (int i = 0; i < 5; i++) {
+      Order o = makeOrder(40.0 + i * 0.01, -74.0);
+      o.setId((long)(i + 20));
+      c2.addAction(Action.makePickup(o));
+    }
+
+    // Both maxed out - should fall back to least-loaded (both same load, picks first)
+    Courier assigned = strategy.assignCourier(Arrays.asList(c1, c2), order);
+    assertThat(assigned).isNotNull();
+  }
+
+  @Test
+  public void shouldHandleCourierWithoutLocation() {
+    Order order = makeOrder(40.7128, -74.0060);
+
+    Courier noLocation = new Courier(new PersonName("X", "Y"), new Address("1", null, "C", "S", "Z"));
+    noLocation.noteAvailable();
+
+    Courier withLocation = makeCourier(40.7130, -74.0062);
+    withLocation.noteAvailable();
+
+    Courier assigned = strategy.assignCourier(Arrays.asList(noLocation, withLocation), order);
+    assertThat(assigned).isNotNull();
+  }
+
+  @Test
+  public void haversineDistanceShouldBeZeroForSamePoint() {
+    double distance = DistanceOptimizedCourierAssignmentStrategy.haversineDistance(40.0, -74.0, 40.0, -74.0);
+    assertThat(distance).isEqualTo(0.0);
+  }
+
+  @Test
+  public void haversineDistanceShouldBePositiveForDifferentPoints() {
+    double distance = DistanceOptimizedCourierAssignmentStrategy.haversineDistance(40.7128, -74.0060, 34.0522, -118.2437);
+    assertThat(distance).isGreaterThan(0);
+  }
+
+  @Test
+  public void estimateDeliveryMinutesShouldIncludeBaseTime() {
+    double minutes = DistanceOptimizedCourierAssignmentStrategy.estimateDeliveryMinutes(0);
+    assertThat(minutes).isEqualTo(5.0);
+  }
+
+  @Test
+  public void estimateDeliveryMinutesShouldScaleWithDistance() {
+    double minutes = DistanceOptimizedCourierAssignmentStrategy.estimateDeliveryMinutes(10.0);
+    assertThat(minutes).isGreaterThan(5.0);
+  }
+
+  private Order makeOrder(double lat, double lng) {
+    Address addr = new Address("1", null, "C", "S", "Z", lat, lng);
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(new MenuItem("i1", "Item", new Money("10.00"))));
+    Restaurant restaurant = new Restaurant("R", addr, menu);
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("i1", "Item", new Money("10.00"), 1));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(1L);
+    return order;
+  }
+
+  private Courier makeCourier(double lat, double lng) {
+    return new Courier(new PersonName("C", "D"), new Address("1", null, "C", "S", "Z", lat, lng));
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/LineItemQuantityChangeTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/LineItemQuantityChangeTest.java
@@ -1,0 +1,22 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LineItemQuantityChangeTest {
+
+  @Test
+  public void shouldStoreAllValues() {
+    Money current = new Money("50.00");
+    Money newTotal = new Money("70.00");
+    Money delta = new Money("20.00");
+
+    LineItemQuantityChange change = new LineItemQuantityChange(current, newTotal, delta);
+
+    assertThat(change.getCurrentOrderTotal()).isEqualTo(current);
+    assertThat(change.getNewOrderTotal()).isEqualTo(newTotal);
+    assertThat(change.getDelta()).isEqualTo(delta);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/MenuItemTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/MenuItemTest.java
@@ -1,0 +1,52 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MenuItemTest {
+
+  @Test
+  public void shouldCreateMenuItem() {
+    MenuItem item = new MenuItem("m1", "Pizza", new Money("12.00"));
+    assertThat(item.getId()).isEqualTo("m1");
+    assertThat(item.getName()).isEqualTo("Pizza");
+    assertThat(item.getPrice()).isEqualTo(new Money("12.00"));
+  }
+
+  @Test
+  public void shouldSetId() {
+    MenuItem item = new MenuItem("m1", "Pizza", new Money("12.00"));
+    item.setId("m2");
+    assertThat(item.getId()).isEqualTo("m2");
+  }
+
+  @Test
+  public void shouldSetName() {
+    MenuItem item = new MenuItem("m1", "Pizza", new Money("12.00"));
+    item.setName("Calzone");
+    assertThat(item.getName()).isEqualTo("Calzone");
+  }
+
+  @Test
+  public void shouldSetPrice() {
+    MenuItem item = new MenuItem("m1", "Pizza", new Money("12.00"));
+    item.setPrice(new Money("15.00"));
+    assertThat(item.getPrice()).isEqualTo(new Money("15.00"));
+  }
+
+  @Test
+  public void shouldHaveEqualsAndHashCode() {
+    MenuItem item1 = new MenuItem("m1", "Pizza", new Money("12.00"));
+    MenuItem item2 = new MenuItem("m1", "Pizza", new Money("12.00"));
+    assertThat(item1).isEqualTo(item2);
+    assertThat(item1.hashCode()).isEqualTo(item2.hashCode());
+  }
+
+  @Test
+  public void shouldHaveToString() {
+    MenuItem item = new MenuItem("m1", "Pizza", new Money("12.00"));
+    assertThat(item.toString()).contains("Pizza");
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderLineItemTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderLineItemTest.java
@@ -1,0 +1,88 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrderLineItemTest {
+
+  @Test
+  public void shouldCreateOrderLineItem() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    assertThat(item.getMenuItemId()).isEqualTo("m1");
+    assertThat(item.getName()).isEqualTo("Burger");
+    assertThat(item.getPrice()).isEqualTo(new Money("10.00"));
+    assertThat(item.getQuantity()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldCalculateTotal() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 3);
+    assertThat(item.getTotal()).isEqualTo(new Money("30.00"));
+  }
+
+  @Test
+  public void shouldCalculateDeltaForChangedQuantity() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    Money delta = item.deltaForChangedQuantity(5);
+    // (5 - 2) * 10 = 30
+    assertThat(delta).isEqualTo(new Money("30.00"));
+  }
+
+  @Test
+  public void shouldCalculateNegativeDelta() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 3);
+    Money delta = item.deltaForChangedQuantity(1);
+    // (1 - 3) * 10 = -20
+    assertThat(delta).isEqualTo(new Money("-20.00"));
+  }
+
+  @Test
+  public void shouldSetQuantity() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    item.setQuantity(5);
+    assertThat(item.getQuantity()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldHaveEqualsAndHashCode() {
+    OrderLineItem item1 = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    OrderLineItem item2 = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    assertThat(item1).isEqualTo(item2);
+    assertThat(item1.hashCode()).isEqualTo(item2.hashCode());
+  }
+
+  @Test
+  public void shouldHaveToString() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    assertThat(item.toString()).isNotEmpty();
+  }
+
+  @Test
+  public void shouldCreateDefaultInstance() {
+    OrderLineItem item = new OrderLineItem();
+    assertThat(item.getMenuItemId()).isNull();
+  }
+
+  @Test
+  public void shouldSetMenuItemId() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    item.setMenuItemId("m2");
+    assertThat(item.getMenuItemId()).isEqualTo("m2");
+  }
+
+  @Test
+  public void shouldSetName() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    item.setName("Pizza");
+    assertThat(item.getName()).isEqualTo("Pizza");
+  }
+
+  @Test
+  public void shouldSetPrice() {
+    OrderLineItem item = new OrderLineItem("m1", "Burger", new Money("10.00"), 2);
+    item.setPrice(new Money("15.00"));
+    assertThat(item.getPrice()).isEqualTo(new Money("15.00"));
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderLineItemsTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderLineItemsTest.java
@@ -1,0 +1,68 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrderLineItemsTest {
+
+  private OrderLineItems orderLineItems;
+
+  @Before
+  public void setUp() {
+    List<OrderLineItem> items = Arrays.asList(
+            new OrderLineItem("m1", "Burger", new Money("10.00"), 2),
+            new OrderLineItem("m2", "Fries", new Money("5.00"), 1)
+    );
+    orderLineItems = new OrderLineItems(items);
+  }
+
+  @Test
+  public void shouldCalculateOrderTotal() {
+    assertThat(orderLineItems.orderTotal()).isEqualTo(new Money("25.00"));
+  }
+
+  @Test
+  public void shouldGetLineItems() {
+    assertThat(orderLineItems.getLineItems()).hasSize(2);
+  }
+
+  @Test
+  public void shouldSetLineItems() {
+    List<OrderLineItem> newItems = Arrays.asList(
+            new OrderLineItem("m3", "Salad", new Money("8.00"), 1)
+    );
+    orderLineItems.setLineItems(newItems);
+    assertThat(orderLineItems.getLineItems()).hasSize(1);
+  }
+
+  @Test
+  public void shouldCalculateLineItemQuantityChange() {
+    Map<String, Integer> revised = new HashMap<>();
+    revised.put("m1", 3); // increase by 1 => +10
+    OrderRevision revision = new OrderRevision(Optional.empty(), revised);
+
+    LineItemQuantityChange change = orderLineItems.lineItemQuantityChange(revision);
+    assertThat(change.getCurrentOrderTotal()).isEqualTo(new Money("25.00"));
+    // delta = (3-2)*10 = 10
+    assertThat(change.getDelta()).isEqualTo(new Money("10.00"));
+    assertThat(change.getNewOrderTotal()).isEqualTo(new Money("35.00"));
+  }
+
+  @Test
+  public void shouldUpdateLineItems() {
+    Map<String, Integer> revised = new HashMap<>();
+    revised.put("m1", 5);
+    revised.put("m2", 3);
+    OrderRevision revision = new OrderRevision(Optional.empty(), revised);
+
+    orderLineItems.updateLineItems(revision);
+
+    assertThat(orderLineItems.getLineItems().get(0).getQuantity()).isEqualTo(5);
+    assertThat(orderLineItems.getLineItems().get(1).getQuantity()).isEqualTo(3);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderRevisionTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderRevisionTest.java
@@ -1,0 +1,52 @@
+package net.chrisrichardson.ftgo.domain;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrderRevisionTest {
+
+  @Test
+  public void shouldCreateOrderRevision() {
+    Map<String, Integer> quantities = new HashMap<>();
+    quantities.put("m1", 3);
+    OrderRevision revision = new OrderRevision(Optional.empty(), quantities);
+
+    assertThat(revision.getDeliveryInformation()).isEmpty();
+    assertThat(revision.getRevisedLineItemQuantities()).containsEntry("m1", 3);
+  }
+
+  @Test
+  public void shouldCreateWithDeliveryInformation() {
+    DeliveryInformation di = new DeliveryInformation();
+    Map<String, Integer> quantities = new HashMap<>();
+    OrderRevision revision = new OrderRevision(Optional.of(di), quantities);
+
+    assertThat(revision.getDeliveryInformation()).isPresent();
+  }
+
+  @Test
+  public void shouldSetDeliveryInformation() {
+    Map<String, Integer> quantities = new HashMap<>();
+    OrderRevision revision = new OrderRevision(Optional.empty(), quantities);
+
+    DeliveryInformation di = new DeliveryInformation();
+    revision.setDeliveryInformation(Optional.of(di));
+    assertThat(revision.getDeliveryInformation()).isPresent();
+  }
+
+  @Test
+  public void shouldSetRevisedLineItemQuantities() {
+    Map<String, Integer> quantities = new HashMap<>();
+    OrderRevision revision = new OrderRevision(Optional.empty(), quantities);
+
+    Map<String, Integer> newQuantities = new HashMap<>();
+    newQuantities.put("m2", 5);
+    revision.setRevisedLineItemQuantities(newQuantities);
+    assertThat(revision.getRevisedLineItemQuantities()).containsEntry("m2", 5);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderTest.java
@@ -1,0 +1,207 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.UnsupportedStateTransitionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class OrderTest {
+
+  private Restaurant restaurant;
+  private List<OrderLineItem> lineItems;
+  private Order order;
+
+  @Before
+  public void setUp() {
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(
+            new MenuItem("item1", "Burger", new Money("10.00")),
+            new MenuItem("item2", "Fries", new Money("5.00"))
+    ));
+    restaurant = new Restaurant("Test Restaurant", new Address("1 Main", null, "NYC", "NY", "10001"), menu);
+    lineItems = Arrays.asList(
+            new OrderLineItem("item1", "Burger", new Money("10.00"), 2),
+            new OrderLineItem("item2", "Fries", new Money("5.00"), 1)
+    );
+    order = new Order(1L, restaurant, lineItems);
+  }
+
+  @Test
+  public void shouldCreateOrderWithApprovedState() {
+    assertThat(order.getOrderState()).isEqualTo(OrderState.APPROVED);
+  }
+
+  @Test
+  public void shouldGetConsumerId() {
+    assertThat(order.getConsumerId()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldGetRestaurant() {
+    assertThat(order.getRestaurant()).isEqualTo(restaurant);
+  }
+
+  @Test
+  public void shouldGetLineItems() {
+    assertThat(order.getLineItems()).hasSize(2);
+  }
+
+  @Test
+  public void shouldCalculateOrderTotal() {
+    // 2 * 10.00 + 1 * 5.00 = 25.00
+    assertThat(order.getOrderTotal()).isEqualTo(new Money("25.00"));
+  }
+
+  @Test
+  public void shouldCancelApprovedOrder() {
+    order.cancel();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.CANCELLED);
+  }
+
+  @Test
+  public void shouldNotCancelNonApprovedOrder() {
+    order.cancel();
+    assertThatThrownBy(() -> order.cancel())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  public void shouldAcceptTicket() {
+    LocalDateTime readyBy = LocalDateTime.now().plusMinutes(30);
+    order.acceptTicket(readyBy);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+  }
+
+  @Test
+  public void shouldNotAcceptTicketIfNotApproved() {
+    order.cancel();
+    assertThatThrownBy(() -> order.acceptTicket(LocalDateTime.now().plusMinutes(30)))
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  public void shouldNotePreparing() {
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    order.notePreparing();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PREPARING);
+  }
+
+  @Test
+  public void shouldNotNotePreparingIfNotAccepted() {
+    assertThatThrownBy(() -> order.notePreparing())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  public void shouldNoteReadyForPickup() {
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.READY_FOR_PICKUP);
+  }
+
+  @Test
+  public void shouldNotNoteReadyForPickupIfNotPreparing() {
+    assertThatThrownBy(() -> order.noteReadyForPickup())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  public void shouldNotePickedUp() {
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    order.notePickedUp();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PICKED_UP);
+  }
+
+  @Test
+  public void shouldNotNotePickedUpIfNotReady() {
+    assertThatThrownBy(() -> order.notePickedUp())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  public void shouldNoteDelivered() {
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    order.notePickedUp();
+    order.noteDelivered();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.DELIVERED);
+  }
+
+  @Test
+  public void shouldNotNoteDeliveredIfNotPickedUp() {
+    assertThatThrownBy(() -> order.noteDelivered())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  public void shouldScheduleCourier() {
+    Courier courier = new Courier(new net.chrisrichardson.ftgo.common.PersonName("John", "Doe"),
+            new Address("1 Elm", null, "NYC", "NY", "10001"));
+    order.schedule(courier);
+    assertThat(order.getAssignedCourier()).isEqualTo(courier);
+  }
+
+  @Test
+  public void shouldSetAndGetId() {
+    order.setId(42L);
+    assertThat(order.getId()).isEqualTo(42L);
+  }
+
+  @Test
+  public void shouldGetVersion() {
+    assertThat(order.getVersion()).isNull();
+  }
+
+  @Test
+  public void fullLifecycleHappyPath() {
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    order.notePickedUp();
+    order.noteDelivered();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.DELIVERED);
+  }
+
+  @Test
+  public void shouldReviseOrderWithNewQuantities() {
+    // Must include all items in the revision map to avoid NPE in updateLineItems
+    java.util.Map<String, Integer> revised = new java.util.HashMap<>();
+    revised.put("item1", 1);
+    revised.put("item2", 1);
+    OrderRevision revision = new OrderRevision(java.util.Optional.empty(), revised);
+
+    order.revise(revision);
+    assertThat(order.getLineItems().get(0).getQuantity()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldReviseOrderWithDeliveryInfo() {
+    DeliveryInformation di = new DeliveryInformation();
+    java.util.Map<String, Integer> revised = new java.util.HashMap<>();
+    OrderRevision revision = new OrderRevision(java.util.Optional.of(di), revised);
+
+    order.revise(revision);
+    // No exception means success
+  }
+
+  @Test
+  public void shouldThrowOnReviseWhenNotApproved() {
+    order.cancel();
+    java.util.Map<String, Integer> revised = new java.util.HashMap<>();
+    OrderRevision revision = new OrderRevision(java.util.Optional.empty(), revised);
+
+    assertThatThrownBy(() -> order.revise(revision))
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/PlanTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/PlanTest.java
@@ -1,0 +1,72 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlanTest {
+
+  private Plan plan;
+  private Order order;
+
+  @Before
+  public void setUp() {
+    plan = new Plan();
+    Restaurant restaurant = new Restaurant("R", new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("i1", "Item", new Money("10.00")))));
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("i1", "Item", new Money("10.00"), 1));
+    order = new Order(1L, restaurant, items);
+    order.setId(1L);
+  }
+
+  @Test
+  public void shouldStartEmpty() {
+    assertThat(plan.getActions()).isEmpty();
+  }
+
+  @Test
+  public void shouldAddAction() {
+    plan.add(Action.makePickup(order));
+    assertThat(plan.getActions()).hasSize(1);
+  }
+
+  @Test
+  public void shouldRemoveDeliveryActions() {
+    plan.add(Action.makePickup(order));
+    plan.add(Action.makeDropoff(order, LocalDateTime.now().plusHours(1)));
+    assertThat(plan.getActions()).hasSize(2);
+
+    plan.removeDelivery(order);
+    assertThat(plan.getActions()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotRemoveActionsForDifferentOrder() {
+    plan.add(Action.makePickup(order));
+
+    Restaurant restaurant2 = new Restaurant("R2", new Address("2", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("i2", "Item2", new Money("5.00")))));
+    List<OrderLineItem> items2 = Arrays.asList(new OrderLineItem("i2", "Item2", new Money("5.00"), 1));
+    Order order2 = new Order(2L, restaurant2, items2);
+    order2.setId(2L);
+
+    plan.removeDelivery(order2);
+    assertThat(plan.getActions()).hasSize(1);
+  }
+
+  @Test
+  public void shouldGetActionsForDelivery() {
+    plan.add(Action.makePickup(order));
+    plan.add(Action.makeDropoff(order, LocalDateTime.now().plusHours(1)));
+
+    List<Action> actions = plan.actionsForDelivery(order);
+    assertThat(actions).hasSize(2);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/RestaurantMenuTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/RestaurantMenuTest.java
@@ -1,0 +1,52 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RestaurantMenuTest {
+
+  @Test
+  public void shouldCreateRestaurantMenu() {
+    List<MenuItem> items = Arrays.asList(
+            new MenuItem("m1", "Pizza", new Money("12.00")),
+            new MenuItem("m2", "Pasta", new Money("14.00"))
+    );
+    RestaurantMenu menu = new RestaurantMenu(items);
+    assertThat(menu.getMenuItems()).hasSize(2);
+  }
+
+  @Test
+  public void shouldHaveEqualsAndHashCode() {
+    List<MenuItem> items1 = Arrays.asList(new MenuItem("m1", "Pizza", new Money("12.00")));
+    List<MenuItem> items2 = Arrays.asList(new MenuItem("m1", "Pizza", new Money("12.00")));
+    RestaurantMenu menu1 = new RestaurantMenu(items1);
+    RestaurantMenu menu2 = new RestaurantMenu(items2);
+    assertThat(menu1).isEqualTo(menu2);
+    assertThat(menu1.hashCode()).isEqualTo(menu2.hashCode());
+  }
+
+  @Test
+  public void shouldHaveToString() {
+    List<MenuItem> items = Arrays.asList(new MenuItem("m1", "Pizza", new Money("12.00")));
+    RestaurantMenu menu = new RestaurantMenu(items);
+    assertThat(menu.toString()).isNotEmpty();
+  }
+
+  @Test
+  public void shouldSetMenuItems() {
+    List<MenuItem> items = Arrays.asList(new MenuItem("m1", "Pizza", new Money("12.00")));
+    RestaurantMenu menu = new RestaurantMenu(items);
+
+    List<MenuItem> newItems = Arrays.asList(
+            new MenuItem("m2", "Pasta", new Money("14.00")),
+            new MenuItem("m3", "Salad", new Money("8.00"))
+    );
+    menu.setMenuItems(newItems);
+    assertThat(menu.getMenuItems()).hasSize(2);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/RestaurantTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/RestaurantTest.java
@@ -1,0 +1,86 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RestaurantTest {
+
+  @Test
+  public void shouldCreateRestaurantWithNameAddressMenu() {
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(
+            new MenuItem("m1", "Pasta", new Money("15.00"))
+    ));
+    Address address = new Address("100 Broadway", null, "NYC", "NY", "10001");
+    Restaurant restaurant = new Restaurant("Italian Place", address, menu);
+
+    assertThat(restaurant.getName()).isEqualTo("Italian Place");
+    assertThat(restaurant.getAddress()).isEqualTo(address);
+  }
+
+  @Test
+  public void shouldCreateRestaurantWithIdNameMenu() {
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(
+            new MenuItem("m1", "Sushi", new Money("20.00"))
+    ));
+    Restaurant restaurant = new Restaurant(5L, "Sushi Bar", menu);
+
+    assertThat(restaurant.getId()).isEqualTo(5L);
+    assertThat(restaurant.getName()).isEqualTo("Sushi Bar");
+  }
+
+  @Test
+  public void shouldFindMenuItem() {
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(
+            new MenuItem("m1", "Burger", new Money("10.00")),
+            new MenuItem("m2", "Fries", new Money("5.00"))
+    ));
+    Restaurant restaurant = new Restaurant("Grill", new Address("1", null, "C", "S", "Z"), menu);
+
+    Optional<MenuItem> item = restaurant.findMenuItem("m2");
+    assertThat(item).isPresent();
+    assertThat(item.get().getName()).isEqualTo("Fries");
+  }
+
+  @Test
+  public void shouldReturnEmptyForMissingMenuItem() {
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(
+            new MenuItem("m1", "Burger", new Money("10.00"))
+    ));
+    Restaurant restaurant = new Restaurant("Grill", new Address("1", null, "C", "S", "Z"), menu);
+
+    Optional<MenuItem> item = restaurant.findMenuItem("nonexistent");
+    assertThat(item).isEmpty();
+  }
+
+  @Test
+  public void shouldThrowOnReviseMenu() {
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(
+            new MenuItem("m1", "Burger", new Money("10.00"))
+    ));
+    Restaurant restaurant = new Restaurant("Grill", new Address("1", null, "C", "S", "Z"), menu);
+
+    assertThatThrownBy(() -> restaurant.reviseMenu(menu))
+            .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void shouldSetAndGetName() {
+    Restaurant restaurant = new Restaurant();
+    restaurant.setName("New Name");
+    assertThat(restaurant.getName()).isEqualTo("New Name");
+  }
+
+  @Test
+  public void shouldSetAndGetId() {
+    Restaurant restaurant = new Restaurant();
+    restaurant.setId(99L);
+    assertThat(restaurant.getId()).isEqualTo(99L);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/ConfigurationClassesTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/ConfigurationClassesTest.java
@@ -1,0 +1,27 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import net.chrisrichardson.ftgo.orderservice.web.OrderWebConfiguration;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationClassesTest {
+
+  @Test
+  public void shouldInstantiateOptimisticOfflineLockException() {
+    OptimisticOfflineLockException ex = new OptimisticOfflineLockException();
+    assertThat(ex).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void shouldInstantiateOrderServiceWithRepositoriesConfiguration() {
+    OrderServiceWithRepositoriesConfiguration config = new OrderServiceWithRepositoriesConfiguration();
+    assertThat(config).isNotNull();
+  }
+
+  @Test
+  public void shouldInstantiateOrderWebConfiguration() {
+    OrderWebConfiguration config = new OrderWebConfiguration();
+    assertThat(config).isNotNull();
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/OrderNotFoundExceptionTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/OrderNotFoundExceptionTest.java
@@ -1,0 +1,14 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrderNotFoundExceptionTest {
+
+  @Test
+  public void shouldStoreOrderId() {
+    OrderNotFoundException ex = new OrderNotFoundException(42L);
+    assertThat(ex).isInstanceOf(RuntimeException.class);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/OrderServiceTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/OrderServiceTest.java
@@ -1,0 +1,289 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.consumerservice.domain.ConsumerService;
+import net.chrisrichardson.ftgo.domain.*;
+import net.chrisrichardson.ftgo.orderservice.web.MenuItemIdAndQuantity;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class OrderServiceTest {
+
+  private OrderRepository orderRepository;
+  private RestaurantRepository restaurantRepository;
+  private MeterRegistry meterRegistry;
+  private ConsumerService consumerService;
+  private CourierRepository courierRepository;
+  private CourierAssignmentStrategy courierAssignmentStrategy;
+  private OrderService orderService;
+  private Counter counter;
+
+  @Before
+  public void setUp() {
+    orderRepository = mock(OrderRepository.class);
+    restaurantRepository = mock(RestaurantRepository.class);
+    meterRegistry = mock(MeterRegistry.class);
+    consumerService = mock(ConsumerService.class);
+    courierRepository = mock(CourierRepository.class);
+    courierAssignmentStrategy = mock(CourierAssignmentStrategy.class);
+    counter = mock(Counter.class);
+
+    when(meterRegistry.counter(anyString())).thenReturn(counter);
+
+    orderService = new OrderService(orderRepository, restaurantRepository,
+            Optional.of(meterRegistry), consumerService, courierRepository, courierAssignmentStrategy);
+  }
+
+  @Test
+  public void shouldCreateOrder() {
+    Restaurant restaurant = new Restaurant("TestR",
+            new Address("1", null, "C", "S", "Z", 40.7, -74.0),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Burger", new Money("10.00")))));
+    restaurant.setId(1L);
+
+    when(restaurantRepository.findById(1L)).thenReturn(Optional.of(restaurant));
+    when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> {
+      Order o = invocation.getArgument(0);
+      o.setId(1L);
+      return o;
+    });
+
+    List<MenuItemIdAndQuantity> items = Arrays.asList(new MenuItemIdAndQuantity("m1", 2));
+    Order order = orderService.createOrder(100L, 1L, items);
+
+    assertThat(order).isNotNull();
+    assertThat(order.getConsumerId()).isEqualTo(100L);
+    verify(consumerService).validateOrderForConsumer(eq(100L), any(Money.class));
+    verify(orderRepository).save(any(Order.class));
+    verify(meterRegistry, times(2)).counter(anyString());
+  }
+
+  @Test
+  public void shouldThrowWhenRestaurantNotFound() {
+    when(restaurantRepository.findById(999L)).thenReturn(Optional.empty());
+
+    List<MenuItemIdAndQuantity> items = Arrays.asList(new MenuItemIdAndQuantity("m1", 1));
+    assertThatThrownBy(() -> orderService.createOrder(1L, 999L, items))
+            .isInstanceOf(RestaurantNotFoundException.class);
+  }
+
+  @Test
+  public void shouldThrowWhenMenuItemNotFound() {
+    Restaurant restaurant = new Restaurant("TestR",
+            new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Burger", new Money("10.00")))));
+    restaurant.setId(1L);
+    when(restaurantRepository.findById(1L)).thenReturn(Optional.of(restaurant));
+
+    List<MenuItemIdAndQuantity> items = Arrays.asList(new MenuItemIdAndQuantity("nonexistent", 1));
+    assertThatThrownBy(() -> orderService.createOrder(1L, 1L, items))
+            .isInstanceOf(InvalidMenuItemIdException.class);
+  }
+
+  @Test
+  public void shouldCancelOrder() {
+    Order order = makeTestOrder();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    Order cancelled = orderService.cancel(1L);
+    assertThat(cancelled.getOrderState()).isEqualTo(OrderState.CANCELLED);
+  }
+
+  @Test
+  public void shouldThrowWhenCancellingNonExistentOrder() {
+    when(orderRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> orderService.cancel(999L))
+            .isInstanceOf(OrderNotFoundException.class);
+  }
+
+  @Test
+  public void shouldReviseOrder() {
+    Order order = makeTestOrder();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    OrderRevision revision = new OrderRevision(Optional.empty(),
+            java.util.Collections.singletonMap("m1", 1));
+    Order revised = orderService.reviseOrder(1L, revision);
+    assertThat(revised).isNotNull();
+  }
+
+  @Test
+  public void shouldAcceptOrder() {
+    Order order = makeTestOrder();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    Courier courier = new Courier(new PersonName("J", "D"),
+            new Address("1", null, "C", "S", "Z", 40.7, -74.0));
+    when(courierRepository.findAllAvailable()).thenReturn(Arrays.asList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+
+    LocalDateTime readyBy = LocalDateTime.now().plusMinutes(30);
+    orderService.accept(1L, readyBy);
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+  }
+
+  @Test
+  public void shouldNotePreparing() {
+    Order order = makeTestOrder();
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    orderService.notePreparing(1L);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PREPARING);
+  }
+
+  @Test
+  public void shouldNoteReadyForPickup() {
+    Order order = makeTestOrder();
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    order.notePreparing();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    orderService.noteReadyForPickup(1L);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.READY_FOR_PICKUP);
+  }
+
+  @Test
+  public void shouldNotePickedUp() {
+    Order order = makeTestOrder();
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    orderService.notePickedUp(1L);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PICKED_UP);
+  }
+
+  @Test
+  public void shouldNoteDelivered() {
+    Order order = makeTestOrder();
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    order.notePickedUp();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    orderService.noteDelivered(1L);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.DELIVERED);
+  }
+
+  @Test
+  public void shouldAcceptOrderWithCourierWithoutLocation() {
+    // Courier without coordinates - exercises fallback branch in estimateDeliveryTime
+    Order order = makeTestOrder();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    Courier courier = new Courier(new PersonName("J", "D"), new Address("1", null, "C", "S", "Z"));
+    when(courierRepository.findAllAvailable()).thenReturn(Arrays.asList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+
+    LocalDateTime readyBy = LocalDateTime.now().plusMinutes(30);
+    orderService.accept(1L, readyBy);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+  }
+
+  @Test
+  public void shouldAcceptOrderWithNullRestaurantAddress() {
+    // Restaurant with null address - exercises another branch
+    Restaurant restaurant = new Restaurant("TestR", null,
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Burger", new Money("10.00")))));
+    restaurant.setId(1L);
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("m1", "Burger", new Money("10.00"), 2));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(1L);
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    Courier courier = new Courier(new PersonName("J", "D"),
+            new Address("1", null, "C", "S", "Z", 40.7, -74.0));
+    when(courierRepository.findAllAvailable()).thenReturn(Arrays.asList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+
+    LocalDateTime readyBy = LocalDateTime.now().plusMinutes(30);
+    orderService.accept(1L, readyBy);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+  }
+
+  @Test
+  public void shouldAcceptOrderWithNullLatitude() {
+    // Restaurant address has null latitude
+    Restaurant restaurant = new Restaurant("TestR",
+            new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Burger", new Money("10.00")))));
+    restaurant.setId(1L);
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("m1", "Burger", new Money("10.00"), 2));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(1L);
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    Courier courier = new Courier(new PersonName("J", "D"),
+            new Address("1", null, "C", "S", "Z", 40.7, -74.0));
+    when(courierRepository.findAllAvailable()).thenReturn(Arrays.asList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+
+    LocalDateTime readyBy = LocalDateTime.now().plusMinutes(30);
+    orderService.accept(1L, readyBy);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+  }
+
+  @Test
+  public void shouldAcceptOrderWithFarAwayCourier() {
+    // Courier far from restaurant - exercises pickupArrival.isAfter(readyBy) == true branch
+    Order order = makeTestOrder();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    // Place courier far away from restaurant (restaurant is at 40.7, -74.0)
+    Courier courier = new Courier(new PersonName("J", "D"),
+            new Address("1", null, "C", "S", "Z", 51.5, -0.1)); // London coords
+    when(courierRepository.findAllAvailable()).thenReturn(Arrays.asList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+
+    // Set readyBy to very soon, so pickupArrival > readyBy
+    LocalDateTime readyBy = LocalDateTime.now().plusMinutes(1);
+    orderService.accept(1L, readyBy);
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+  }
+
+  @Test
+  public void shouldCreateOrderWithoutMeterRegistry() {
+    OrderService serviceNoMeter = new OrderService(orderRepository, restaurantRepository,
+            Optional.empty(), consumerService, courierRepository, courierAssignmentStrategy);
+
+    Restaurant restaurant = new Restaurant("TestR",
+            new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Burger", new Money("10.00")))));
+    restaurant.setId(1L);
+    when(restaurantRepository.findById(1L)).thenReturn(Optional.of(restaurant));
+    when(orderRepository.save(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    List<MenuItemIdAndQuantity> items = Arrays.asList(new MenuItemIdAndQuantity("m1", 2));
+    Order order = serviceNoMeter.createOrder(100L, 1L, items);
+    assertThat(order).isNotNull();
+  }
+
+  private Order makeTestOrder() {
+    Restaurant restaurant = new Restaurant("TestR",
+            new Address("1", null, "C", "S", "Z", 40.7, -74.0),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Burger", new Money("10.00")))));
+    restaurant.setId(1L);
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("m1", "Burger", new Money("10.00"), 2));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(1L);
+    return order;
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/RevisedOrderTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/RevisedOrderTest.java
@@ -1,0 +1,30 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.*;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RevisedOrderTest {
+
+  @Test
+  public void shouldStoreOrderAndChange() {
+    Restaurant restaurant = new Restaurant("R",
+            new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Item", new Money("10.00")))));
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("m1", "Item", new Money("10.00"), 2));
+    Order order = new Order(1L, restaurant, items);
+
+    LineItemQuantityChange change = new LineItemQuantityChange(
+            new Money("20.00"), new Money("30.00"), new Money("10.00"));
+
+    RevisedOrder revisedOrder = new RevisedOrder(order, change);
+    assertThat(revisedOrder.getOrder()).isEqualTo(order);
+    assertThat(revisedOrder.getChange()).isEqualTo(change);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/GetOrderResponseTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/GetOrderResponseTest.java
@@ -1,0 +1,48 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.Action;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GetOrderResponseTest {
+
+  @Test
+  public void shouldCreateWithAllFields() {
+    LocalDateTime deliveryTime = LocalDateTime.now().plusHours(1);
+    GetOrderResponse response = new GetOrderResponse(1L, "APPROVED", new Money("25.00"),
+            "Test Restaurant", 10L, Collections.emptyList(), deliveryTime);
+
+    assertThat(response.getOrderId()).isEqualTo(1L);
+    assertThat(response.getState()).isEqualTo("APPROVED");
+    assertThat(response.getOrderTotal()).isEqualTo(new Money("25.00"));
+    assertThat(response.getRestaurantName()).isEqualTo("Test Restaurant");
+    assertThat(response.getAssignedCourier()).isEqualTo(10L);
+    assertThat(response.getCourierActions()).isEmpty();
+    assertThat(response.getEstimatedDeliveryTime()).isEqualTo(deliveryTime);
+  }
+
+  @Test
+  public void shouldSetAndGetAllFields() {
+    GetOrderResponse response = new GetOrderResponse(0L, null, null, null, null, null, null);
+    response.setOrderId(2L);
+    response.setState("CANCELLED");
+    response.setOrderTotal(new Money("10.00"));
+    response.setAssignedCourier(5L);
+    response.setCourierActions(Collections.emptyList());
+    LocalDateTime time = LocalDateTime.now();
+    response.setEstimatedDeliveryTime(time);
+
+    assertThat(response.getOrderId()).isEqualTo(2L);
+    assertThat(response.getState()).isEqualTo("CANCELLED");
+    assertThat(response.getOrderTotal()).isEqualTo(new Money("10.00"));
+    assertThat(response.getAssignedCourier()).isEqualTo(5L);
+    assertThat(response.getCourierActions()).isEmpty();
+    assertThat(response.getEstimatedDeliveryTime()).isEqualTo(time);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/GetRestaurantResponseTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/GetRestaurantResponseTest.java
@@ -1,0 +1,21 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GetRestaurantResponseTest {
+
+  @Test
+  public void shouldCreateWithId() {
+    GetRestaurantResponse response = new GetRestaurantResponse(42L);
+    assertThat(response.getRestaurantId()).isEqualTo(42L);
+  }
+
+  @Test
+  public void shouldSetAndGetRestaurantId() {
+    GetRestaurantResponse response = new GetRestaurantResponse(1L);
+    response.setRestaurantId(99L);
+    assertThat(response.getRestaurantId()).isEqualTo(99L);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/MenuItemIdAndQuantityTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/MenuItemIdAndQuantityTest.java
@@ -1,0 +1,22 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MenuItemIdAndQuantityTest {
+
+  @Test
+  public void shouldCreateWithConstructor() {
+    MenuItemIdAndQuantity item = new MenuItemIdAndQuantity("m1", 3);
+    assertThat(item.getMenuItemId()).isEqualTo("m1");
+    assertThat(item.getQuantity()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldSetMenuItemId() {
+    MenuItemIdAndQuantity item = new MenuItemIdAndQuantity("m1", 1);
+    item.setMenuItemId("m2");
+    assertThat(item.getMenuItemId()).isEqualTo("m2");
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/OrderControllerUnitTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/OrderControllerUnitTest.java
@@ -1,0 +1,188 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.*;
+import net.chrisrichardson.ftgo.orderservice.domain.OrderNotFoundException;
+import net.chrisrichardson.ftgo.orderservice.domain.OrderService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class OrderControllerUnitTest {
+
+  private OrderService orderService;
+  private OrderRepository orderRepository;
+  private OrderController controller;
+
+  @Before
+  public void setUp() {
+    orderService = mock(OrderService.class);
+    orderRepository = mock(OrderRepository.class);
+    controller = new OrderController(orderService, orderRepository);
+  }
+
+  @Test
+  public void shouldGetOrderReturns200() {
+    Order order = makeTestOrder();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    ResponseEntity<GetOrderResponse> response = controller.getOrder(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getOrderId()).isEqualTo(1L);
+    assertThat(response.getBody().getState()).isEqualTo("APPROVED");
+  }
+
+  @Test
+  public void shouldGetOrderReturns404WhenNotFound() {
+    when(orderRepository.findById(999L)).thenReturn(Optional.empty());
+
+    ResponseEntity<GetOrderResponse> response = controller.getOrder(999L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldGetOrdersByConsumerId() {
+    Order order = makeTestOrder();
+    when(orderRepository.findAllByConsumerId(1L)).thenReturn(Arrays.asList(order));
+
+    ResponseEntity<List<GetOrderResponse>> response = controller.getOrders(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).hasSize(1);
+  }
+
+  @Test
+  public void shouldCancelOrder() {
+    Order order = makeTestOrder();
+    when(orderService.cancel(1L)).thenReturn(order);
+
+    ResponseEntity<GetOrderResponse> response = controller.cancel(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  public void shouldReturn404WhenCancellingNonExistent() {
+    when(orderService.cancel(999L)).thenThrow(new OrderNotFoundException(999L));
+
+    ResponseEntity<GetOrderResponse> response = controller.cancel(999L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReviseOrder() {
+    Order order = makeTestOrder();
+    when(orderService.reviseOrder(anyLong(), any(OrderRevision.class))).thenReturn(order);
+
+    net.chrisrichardson.ftgo.orderservice.api.web.ReviseOrderRequest request =
+            new net.chrisrichardson.ftgo.orderservice.api.web.ReviseOrderRequest(Collections.singletonMap("m1", 3));
+
+    ResponseEntity<GetOrderResponse> response = controller.revise(1L, request);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  public void shouldReturn404WhenRevisingNonExistent() {
+    when(orderService.reviseOrder(anyLong(), any(OrderRevision.class)))
+            .thenThrow(new OrderNotFoundException(999L));
+
+    net.chrisrichardson.ftgo.orderservice.api.web.ReviseOrderRequest request =
+            new net.chrisrichardson.ftgo.orderservice.api.web.ReviseOrderRequest(Collections.singletonMap("m1", 3));
+
+    ResponseEntity<GetOrderResponse> response = controller.revise(999L, request);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldCreateOrder() {
+    Order order = makeTestOrder();
+    when(orderService.createOrder(anyLong(), anyLong(), anyList())).thenReturn(order);
+
+    net.chrisrichardson.ftgo.orderservice.api.web.CreateOrderRequest request =
+            new net.chrisrichardson.ftgo.orderservice.api.web.CreateOrderRequest(
+                    1L, 1L,
+                    Arrays.asList(new net.chrisrichardson.ftgo.orderservice.api.web.CreateOrderRequest.LineItem("m1", 2))
+            );
+
+    net.chrisrichardson.ftgo.orderservice.api.web.CreateOrderResponse response = controller.create(request);
+    assertThat(response.getOrderId()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldAcceptOrder() {
+    LocalDateTime readyBy = LocalDateTime.now().plusMinutes(30);
+    net.chrisrichardson.ftgo.orderservice.api.web.OrderAcceptance acceptance =
+            new net.chrisrichardson.ftgo.orderservice.api.web.OrderAcceptance(readyBy);
+
+    ResponseEntity<String> response = controller.accept(1L, acceptance);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).accept(1L, readyBy);
+  }
+
+  @Test
+  public void shouldNotePreparing() {
+    ResponseEntity<String> response = controller.preparing(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).notePreparing(1L);
+  }
+
+  @Test
+  public void shouldNoteReady() {
+    ResponseEntity<String> response = controller.ready(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).noteReadyForPickup(1L);
+  }
+
+  @Test
+  public void shouldNotePickedUp() {
+    ResponseEntity<String> response = controller.pickedup(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).notePickedUp(1L);
+  }
+
+  @Test
+  public void shouldNoteDelivered() {
+    ResponseEntity<String> response = controller.delivered(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).noteDelivered(1L);
+  }
+
+  @Test
+  public void shouldGetOrderWithAssignedCourier() {
+    Order order = makeTestOrder();
+    net.chrisrichardson.ftgo.common.PersonName courierName = new net.chrisrichardson.ftgo.common.PersonName("John", "Doe");
+    Courier courier = new Courier(courierName, new Address("1", null, "C", "S", "Z", 40.0, -74.0));
+    courier.noteAvailable();
+    Action dropoff = Action.makeDropoff(order, LocalDateTime.now().plusMinutes(30));
+    courier.addAction(dropoff);
+    order.schedule(courier);
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    ResponseEntity<GetOrderResponse> response = controller.getOrder(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    // Courier has no persisted ID so assignedCourier is null in response
+    // but courierActions is populated from courier.actionsForDelivery(order)
+    assertThat(response.getBody().getCourierActions()).isNotEmpty();
+    assertThat(response.getBody().getEstimatedDeliveryTime()).isNotNull();
+  }
+
+  private Order makeTestOrder() {
+    Restaurant restaurant = new Restaurant("TestR",
+            new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Burger", new Money("10.00")))));
+    restaurant.setId(1L);
+    List<OrderLineItem> items = Arrays.asList(new OrderLineItem("m1", "Burger", new Money("10.00"), 2));
+    Order order = new Order(1L, restaurant, items);
+    order.setId(1L);
+    return order;
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/TicketControllerTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/TicketControllerTest.java
@@ -1,0 +1,17 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import net.chrisrichardson.ftgo.orderservice.domain.OrderService;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class TicketControllerTest {
+
+  @Test
+  public void shouldCreateTicketController() {
+    OrderService orderService = mock(OrderService.class);
+    TicketController controller = new TicketController(orderService);
+    assertThat(controller).isNotNull();
+  }
+}

--- a/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/ConfigurationClassesTest.java
+++ b/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/ConfigurationClassesTest.java
@@ -1,0 +1,27 @@
+package net.chrisrichardson.ftgo.restaurantservice;
+
+import net.chrisrichardson.ftgo.restaurantservice.domain.RestaurantServiceDomainConfiguration;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationClassesTest {
+
+  @Test
+  public void shouldInstantiateRestaurantServiceDomainConfiguration() {
+    RestaurantServiceDomainConfiguration config = new RestaurantServiceDomainConfiguration();
+    assertThat(config).isNotNull();
+  }
+
+  @Test
+  public void shouldCreateRestaurantServiceBean() {
+    RestaurantServiceDomainConfiguration config = new RestaurantServiceDomainConfiguration();
+    assertThat(config.restaurantService()).isNotNull();
+  }
+
+  @Test
+  public void shouldInstantiateRestaurantServiceConfiguration() {
+    RestaurantServiceConfiguration config = new RestaurantServiceConfiguration();
+    assertThat(config).isNotNull();
+  }
+}

--- a/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/domain/RestaurantServiceTest.java
+++ b/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/domain/RestaurantServiceTest.java
@@ -1,0 +1,75 @@
+package net.chrisrichardson.ftgo.restaurantservice.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.Restaurant;
+import net.chrisrichardson.ftgo.domain.RestaurantMenu;
+import net.chrisrichardson.ftgo.domain.RestaurantRepository;
+import net.chrisrichardson.ftgo.domain.MenuItem;
+import net.chrisrichardson.ftgo.restaurantservice.events.CreateRestaurantRequest;
+import net.chrisrichardson.ftgo.restaurantservice.events.MenuItemDTO;
+import net.chrisrichardson.ftgo.restaurantservice.events.RestaurantMenuDTO;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class RestaurantServiceTest {
+
+  @Mock
+  private RestaurantRepository restaurantRepository;
+
+  @InjectMocks
+  private RestaurantService restaurantService;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void shouldCreateRestaurant() {
+    RestaurantMenuDTO menuDTO = new RestaurantMenuDTO(Arrays.asList(
+            new MenuItemDTO("m1", "Pizza", new Money("12.00"))
+    ));
+    Address address = new Address("100 Broadway", null, "NYC", "NY", "10001");
+    CreateRestaurantRequest request = new CreateRestaurantRequest("Italian Place", address, menuDTO);
+
+    when(restaurantRepository.save(any(Restaurant.class))).thenAnswer(inv -> {
+      Restaurant r = inv.getArgument(0);
+      r.setId(1L);
+      return r;
+    });
+
+    Restaurant result = restaurantService.create(request);
+    assertThat(result.getName()).isEqualTo("Italian Place");
+    verify(restaurantRepository).save(any(Restaurant.class));
+  }
+
+  @Test
+  public void shouldFindById() {
+    Restaurant restaurant = new Restaurant("Test",
+            new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Item", new Money("10.00")))));
+    when(restaurantRepository.findById(1L)).thenReturn(Optional.of(restaurant));
+
+    Optional<Restaurant> result = restaurantService.findById(1L);
+    assertThat(result).isPresent();
+    assertThat(result.get().getName()).isEqualTo("Test");
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenNotFound() {
+    when(restaurantRepository.findById(999L)).thenReturn(Optional.empty());
+
+    Optional<Restaurant> result = restaurantService.findById(999L);
+    assertThat(result).isEmpty();
+  }
+}

--- a/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/web/ResponseClassesTest.java
+++ b/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/web/ResponseClassesTest.java
@@ -1,0 +1,37 @@
+package net.chrisrichardson.ftgo.restaurantservice.web;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResponseClassesTest {
+
+  @Test
+  public void shouldCreateRestaurantResponse() {
+    CreateRestaurantResponse response = new CreateRestaurantResponse(1L);
+    assertThat(response.getId()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldSetRestaurantResponseId() {
+    CreateRestaurantResponse response = new CreateRestaurantResponse();
+    response.setId(99L);
+    assertThat(response.getId()).isEqualTo(99L);
+  }
+
+  @Test
+  public void shouldCreateGetRestaurantResponse() {
+    GetRestaurantResponse response = new GetRestaurantResponse(1L, "Italian");
+    assertThat(response.getId()).isEqualTo(1L);
+    assertThat(response.getName()).isEqualTo("Italian");
+  }
+
+  @Test
+  public void shouldSetGetRestaurantResponseFields() {
+    GetRestaurantResponse response = new GetRestaurantResponse();
+    response.setId(5L);
+    response.setName("Mexican");
+    assertThat(response.getId()).isEqualTo(5L);
+    assertThat(response.getName()).isEqualTo("Mexican");
+  }
+}

--- a/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/web/RestaurantControllerTest.java
+++ b/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/web/RestaurantControllerTest.java
@@ -1,0 +1,76 @@
+package net.chrisrichardson.ftgo.restaurantservice.web;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.MenuItem;
+import net.chrisrichardson.ftgo.domain.Restaurant;
+import net.chrisrichardson.ftgo.domain.RestaurantMenu;
+import net.chrisrichardson.ftgo.restaurantservice.domain.RestaurantService;
+import net.chrisrichardson.ftgo.restaurantservice.events.CreateRestaurantRequest;
+import net.chrisrichardson.ftgo.restaurantservice.events.MenuItemDTO;
+import net.chrisrichardson.ftgo.restaurantservice.events.RestaurantMenuDTO;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class RestaurantControllerTest {
+
+  @Mock
+  private RestaurantService restaurantService;
+
+  @InjectMocks
+  private RestaurantController controller;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void shouldCreateRestaurant() {
+    Restaurant restaurant = new Restaurant("Italian",
+            new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Pizza", new Money("12.00")))));
+    restaurant.setId(1L);
+    when(restaurantService.create(any(CreateRestaurantRequest.class))).thenReturn(restaurant);
+
+    RestaurantMenuDTO menuDTO = new RestaurantMenuDTO(Arrays.asList(
+            new MenuItemDTO("m1", "Pizza", new Money("12.00"))
+    ));
+    CreateRestaurantRequest request = new CreateRestaurantRequest("Italian", new Address("1", null, "C", "S", "Z"), menuDTO);
+
+    CreateRestaurantResponse response = controller.create(request);
+    assertThat(response.getId()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldGetRestaurantReturns200() {
+    Restaurant restaurant = new Restaurant("TestR",
+            new Address("1", null, "C", "S", "Z"),
+            new RestaurantMenu(Arrays.asList(new MenuItem("m1", "Item", new Money("10.00")))));
+    restaurant.setId(1L);
+    when(restaurantService.findById(1L)).thenReturn(Optional.of(restaurant));
+
+    ResponseEntity<GetRestaurantResponse> response = controller.get(1L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getName()).isEqualTo("TestR");
+  }
+
+  @Test
+  public void shouldGetRestaurantReturns404WhenNotFound() {
+    when(restaurantService.findById(999L)).thenReturn(Optional.empty());
+
+    ResponseEntity<GetRestaurantResponse> response = controller.get(999L);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+}


### PR DESCRIPTION
## Summary

Adds JaCoCo coverage enforcement and 47 new test files achieving **98.1% line coverage** and **88.7% branch coverage** across all business logic modules — exceeding the ≥95% line / ≥85% branch targets.

### Coverage Results

| Module | Line Coverage | Branch Coverage |
|--------|-------------|----------------|
| ftgo-common | 99.6% (245/246) | 92.9% (39/42) |
| ftgo-domain | 96.7% (295/305) | 85.5% (53/62) |
| ftgo-order-service | 97.2% (175/180) | 88.9% (16/18) |
| ftgo-consumer-service | 100% (22/22) | — |
| ftgo-courier-service | 100% (44/44) | 100% (2/2) |
| ftgo-restaurant-service | 100% (36/36) | — |
| **Overall** | **98.1% (817/833)** | **88.7% (110/124)** |

### What changed

**Build config** (`build.gradle`):
- `apply plugin: "jacoco"` on all subprojects
- `jacocoTestCoverageVerification` with `LINE >= 0.95`, `BRANCH >= 0.85`
- Test deps: `mockito-core:4.11.0`, `mockito-inline:4.11.0`, `assertj-core:3.24.2`
- JVM `--add-opens` args for Java 17 + Mockito compatibility

**Test files** (47 new files, ~3000 lines):
- `ftgo-common`: Money, Address, PersonName, ErrorResponse, exceptions, API tracking (interceptor, controller stats, configuration)
- `ftgo-domain`: Order state machine (full lifecycle, revise, cancel), Courier (location, availability, actions), Restaurant, Plan, Action, Consumer, `DistanceOptimizedCourierAssignmentStrategy`
- `ftgo-order-service`: `OrderService` (create, cancel, revise, accept with distance estimation branches), `OrderController` (all endpoints), DTOs, TicketController
- `ftgo-consumer-service`: ConsumerService, ConsumerController, GetConsumerResponse
- `ftgo-courier-service`: CourierService, CourierController
- `ftgo-restaurant-service`: RestaurantService, RestaurantController, response DTOs

All I/O boundaries mocked (repositories, HTTP clients). AAA pattern throughout. No production code modifications.

Link to Devin session: https://app.devin.ai/sessions/e46d197115dd482292adec1d248154ae
Requested by: @tobydrinkall
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->