### PR TITLE
Add comprehensive unit tests with JaCoCo coverage enforcement (95.7% line / 88.7% branch)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ plugins {
 subprojects {
 
     apply plugin: "java"
+    apply plugin: "jacoco"
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
 
@@ -40,4 +41,89 @@ subprojects {
 
     }
 
+    dependencies {
+        testCompile "org.junit.jupiter:junit-jupiter-api:5.9.3"
+        testCompile "org.junit.jupiter:junit-jupiter-params:5.9.3"
+        testRuntime "org.junit.jupiter:junit-jupiter-engine:5.9.3"
+        testRuntime "org.junit.vintage:junit-vintage-engine:5.9.3"
+        testCompile "org.mockito:mockito-core:4.11.0"
+        testCompile "org.mockito:mockito-junit-jupiter:4.11.0"
+        testCompile "org.assertj:assertj-core:3.24.2"
+    }
+
+    test {
+        useJUnitPlatform()
+        jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+                '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED',
+                '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+    }
+
+    jacoco {
+        toolVersion = "0.8.10"
+    }
+
+    jacocoTestReport {
+        dependsOn test
+        reports {
+            xml.enabled true
+            html.enabled true
+        }
+    }
+
+    jacocoTestCoverageVerification {
+        dependsOn jacocoTestReport
+        afterEvaluate {
+            classDirectories = files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: [
+                    '**/*Configuration.class',
+                    '**/*Configuration$*.class'
+                ])
+            })
+        }
+        violationRules {
+            rule {
+                limit {
+                    counter = 'LINE'
+                    value = 'COVEREDRATIO'
+                    minimum = 0.95
+                }
+            }
+            rule {
+                limit {
+                    counter = 'BRANCH'
+                    value = 'COVEREDRATIO'
+                    minimum = 0.85
+                }
+            }
+        }
+    }
+
+}
+
+apply plugin: "jacoco"
+
+task jacocoAggregateReport(type: JacocoReport) {
+    def testProjects = subprojects.findAll { p ->
+        !p.name.startsWith('ftgo-end-to-end') &&
+        !p.name.startsWith('ftgo-flyway') &&
+        !p.name.startsWith('buildSrc') &&
+        !p.name.startsWith('common-swagger') &&
+        !p.name.startsWith('ftgo-test-util')
+    }
+
+    dependsOn testProjects.collect { it.tasks.withType(Test) }
+
+    additionalSourceDirs = files(testProjects.collect { it.sourceSets.main.allSource.srcDirs }.flatten())
+    sourceDirectories = files(testProjects.collect { it.sourceSets.main.allSource.srcDirs }.flatten())
+    classDirectories = files(testProjects.collect { it.sourceSets.main.output }.flatten())
+    executionData = files(testProjects.collect {
+        it.tasks.withType(Test).collect { t -> t.extensions.getByType(JacocoTaskExtension).destinationFile }
+    }.flatten().findAll { it.exists() })
+
+    reports {
+        xml.enabled true
+        html.enabled true
+        html.destination file("${buildDir}/reports/jacoco/aggregate/html")
+        xml.destination file("${buildDir}/reports/jacoco/aggregate/jacocoAggregateReport.xml")
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ task jacocoAggregateReport(type: JacocoReport) {
     classDirectories = files(testProjects.collect { it.sourceSets.main.output }.flatten())
     executionData = files(testProjects.collect {
         it.tasks.withType(Test).collect { t -> t.extensions.getByType(JacocoTaskExtension).destinationFile }
-    }.flatten().findAll { it.exists() })
+    }.flatten())
 
     reports {
         xml.enabled true

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/AddressTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/AddressTest.java
@@ -1,0 +1,58 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AddressTest {
+
+  @Test
+  void shouldCreateAddressWithBasicFields() {
+    Address address = new Address("123 Main St", "Apt 4", "Oakland", "CA", "94612");
+
+    assertThat(address.getStreet1()).isEqualTo("123 Main St");
+    assertThat(address.getStreet2()).isEqualTo("Apt 4");
+    assertThat(address.getCity()).isEqualTo("Oakland");
+    assertThat(address.getState()).isEqualTo("CA");
+    assertThat(address.getZip()).isEqualTo("94612");
+    assertThat(address.getLatitude()).isNull();
+    assertThat(address.getLongitude()).isNull();
+  }
+
+  @Test
+  void shouldCreateAddressWithCoordinates() {
+    Address address = new Address("123 Main St", "Apt 4", "Oakland", "CA", "94612", 37.8044, -122.2712);
+
+    assertThat(address.getLatitude()).isEqualTo(37.8044);
+    assertThat(address.getLongitude()).isEqualTo(-122.2712);
+  }
+
+  @Test
+  void shouldCreateDefaultAddress() {
+    Address address = new Address();
+
+    assertThat(address.getStreet1()).isNull();
+    assertThat(address.getCity()).isNull();
+    assertThat(address.getLatitude()).isNull();
+  }
+
+  @Test
+  void shouldSupportSetters() {
+    Address address = new Address();
+    address.setStreet1("456 Oak Ave");
+    address.setStreet2("Suite 100");
+    address.setCity("San Francisco");
+    address.setState("CA");
+    address.setZip("94102");
+    address.setLatitude(37.7749);
+    address.setLongitude(-122.4194);
+
+    assertThat(address.getStreet1()).isEqualTo("456 Oak Ave");
+    assertThat(address.getStreet2()).isEqualTo("Suite 100");
+    assertThat(address.getCity()).isEqualTo("San Francisco");
+    assertThat(address.getState()).isEqualTo("CA");
+    assertThat(address.getZip()).isEqualTo("94102");
+    assertThat(address.getLatitude()).isEqualTo(37.7749);
+    assertThat(address.getLongitude()).isEqualTo(-122.4194);
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/CommonJsonMapperInitializerTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/CommonJsonMapperInitializerTest.java
@@ -1,0 +1,26 @@
+package net.chrisrichardson.ftgo.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class CommonJsonMapperInitializerTest {
+
+  @Spy
+  private ObjectMapper objectMapper;
+
+  @InjectMocks
+  private CommonJsonMapperInitializer initializer;
+
+  @Test
+  void shouldRegisterModules() {
+    initializer.initialize();
+    assertThat(objectMapper.getRegisteredModuleIds()).isNotEmpty();
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/ErrorResponseTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/ErrorResponseTest.java
@@ -1,0 +1,32 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ErrorResponseTest {
+
+  @Test
+  void shouldCreateErrorResponseWithAllFields() {
+    ErrorResponse response = new ErrorResponse(404, "Not Found", "Order not found", "/orders/1", "abc-123");
+
+    assertThat(response.getStatus()).isEqualTo(404);
+    assertThat(response.getError()).isEqualTo("Not Found");
+    assertThat(response.getMessage()).isEqualTo("Order not found");
+    assertThat(response.getPath()).isEqualTo("/orders/1");
+    assertThat(response.getCorrelationId()).isEqualTo("abc-123");
+    assertThat(response.getTimestamp()).isNotNull();
+  }
+
+  @Test
+  void shouldCreateDefaultErrorResponse() {
+    ErrorResponse response = new ErrorResponse();
+
+    assertThat(response.getStatus()).isEqualTo(0);
+    assertThat(response.getError()).isNull();
+    assertThat(response.getMessage()).isNull();
+    assertThat(response.getPath()).isNull();
+    assertThat(response.getCorrelationId()).isNull();
+    assertThat(response.getTimestamp()).isNull();
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/MoneyAdditionalTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/MoneyAdditionalTest.java
@@ -1,0 +1,64 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MoneyAdditionalTest {
+
+  @Test
+  void shouldCreateFromBigDecimal() {
+    Money money = new Money(new BigDecimal("12.34"));
+    assertThat(money.asString()).isEqualTo("12.34");
+  }
+
+  @Test
+  void shouldCreateFromString() {
+    Money money = new Money("99.99");
+    assertThat(money.asString()).isEqualTo("99.99");
+  }
+
+  @Test
+  void shouldCreateFromInt() {
+    Money money = new Money(42);
+    assertThat(money.asString()).isEqualTo("42");
+  }
+
+  @Test
+  void shouldHaveZeroConstant() {
+    assertThat(Money.ZERO.asString()).isEqualTo("0");
+  }
+
+  @Test
+  void shouldBeEqualToSelf() {
+    Money money = new Money("10.00");
+    assertThat(money).isEqualTo(money);
+  }
+
+  @Test
+  void shouldNotBeEqualToNull() {
+    Money money = new Money("10.00");
+    assertThat(money).isNotEqualTo(null);
+  }
+
+  @Test
+  void shouldNotBeEqualToDifferentClass() {
+    Money money = new Money("10.00");
+    assertThat(money).isNotEqualTo("10.00");
+  }
+
+  @Test
+  void shouldHaveConsistentHashCode() {
+    Money money1 = new Money("10.00");
+    Money money2 = new Money("10.00");
+    assertThat(money1.hashCode()).isEqualTo(money2.hashCode());
+  }
+
+  @Test
+  void shouldHaveToString() {
+    Money money = new Money("10.00");
+    assertThat(money.toString()).contains("10.00");
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/MoneyModuleTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/MoneyModuleTest.java
@@ -1,0 +1,14 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MoneyModuleTest {
+
+  @Test
+  void shouldReturnModuleName() {
+    MoneyModule module = new MoneyModule();
+    assertThat(module.getModuleName()).isEqualTo("FtgoCommonMOdule");
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/NotYetImplementedExceptionTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/NotYetImplementedExceptionTest.java
@@ -1,0 +1,14 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotYetImplementedExceptionTest {
+
+  @Test
+  void shouldBeARuntimeException() {
+    NotYetImplementedException ex = new NotYetImplementedException();
+    assertThat(ex).isInstanceOf(RuntimeException.class);
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/PersonNameTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/PersonNameTest.java
@@ -1,0 +1,26 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersonNameTest {
+
+  @Test
+  void shouldCreatePersonName() {
+    PersonName name = new PersonName("John", "Doe");
+
+    assertThat(name.getFirstName()).isEqualTo("John");
+    assertThat(name.getLastName()).isEqualTo("Doe");
+  }
+
+  @Test
+  void shouldSupportSetters() {
+    PersonName name = new PersonName("John", "Doe");
+    name.setFirstName("Jane");
+    name.setLastName("Smith");
+
+    assertThat(name.getFirstName()).isEqualTo("Jane");
+    assertThat(name.getLastName()).isEqualTo("Smith");
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/UnsupportedStateTransitionExceptionTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/UnsupportedStateTransitionExceptionTest.java
@@ -1,0 +1,18 @@
+package net.chrisrichardson.ftgo.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnsupportedStateTransitionExceptionTest {
+
+  private enum TestState { ACTIVE, INACTIVE }
+
+  @Test
+  void shouldContainCurrentStateInMessage() {
+    UnsupportedStateTransitionException ex = new UnsupportedStateTransitionException(TestState.ACTIVE);
+
+    assertThat(ex.getMessage()).contains("ACTIVE");
+    assertThat(ex.getMessage()).contains("current state:");
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogTest.java
@@ -1,0 +1,53 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiRequestLogTest {
+
+  @Test
+  void shouldCreateLogEntry() {
+    ApiRequestLog log = new ApiRequestLog("corr-123", "GET", "/orders/1", "q=test", "127.0.0.1", "Mozilla/5.0");
+
+    assertThat(log.getCorrelationId()).isEqualTo("corr-123");
+    assertThat(log.getHttpMethod()).isEqualTo("GET");
+    assertThat(log.getRequestUri()).isEqualTo("/orders/1");
+    assertThat(log.getQueryString()).isEqualTo("q=test");
+    assertThat(log.getRemoteAddr()).isEqualTo("127.0.0.1");
+    assertThat(log.getUserAgent()).isEqualTo("Mozilla/5.0");
+    assertThat(log.getRequestTimestamp()).isNotNull();
+    assertThat(log.getResponseStatus()).isNull();
+    assertThat(log.getDurationMs()).isNull();
+    assertThat(log.getErrorMessage()).isNull();
+  }
+
+  @Test
+  void shouldCompleteWithoutError() {
+    ApiRequestLog log = new ApiRequestLog("corr-123", "GET", "/orders", null, "127.0.0.1", null);
+    log.complete(200, 50L);
+
+    assertThat(log.getResponseStatus()).isEqualTo(200);
+    assertThat(log.getDurationMs()).isEqualTo(50L);
+    assertThat(log.getErrorMessage()).isNull();
+  }
+
+  @Test
+  void shouldCompleteWithError() {
+    ApiRequestLog log = new ApiRequestLog("corr-456", "POST", "/orders", null, "127.0.0.1", null);
+    log.complete(500, 120L, "Internal error");
+
+    assertThat(log.getResponseStatus()).isEqualTo(500);
+    assertThat(log.getDurationMs()).isEqualTo(120L);
+    assertThat(log.getErrorMessage()).isEqualTo("Internal error");
+  }
+
+  @Test
+  void shouldCreateDefaultLogEntry() {
+    ApiRequestLog log = new ApiRequestLog();
+
+    assertThat(log.getId()).isNull();
+    assertThat(log.getCorrelationId()).isNull();
+    assertThat(log.getHttpMethod()).isNull();
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingControllerTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingControllerTest.java
@@ -1,0 +1,163 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApiTrackingControllerTest {
+
+  @Mock
+  private ApiRequestLogRepository apiRequestLogRepository;
+
+  private ApiTrackingController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new ApiTrackingController(apiRequestLogRepository);
+  }
+
+  @Test
+  void shouldGetRecentLogs() {
+    ApiRequestLog log = new ApiRequestLog("corr-1", "GET", "/orders", null, "127.0.0.1", null);
+    when(apiRequestLogRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Collections.singletonList(log));
+
+    ResponseEntity<List<ApiRequestLog>> response = controller.getRecentLogs(60);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).hasSize(1);
+  }
+
+  @Test
+  void shouldGetErrors() {
+    when(apiRequestLogRepository.findErrorsSince(any(LocalDateTime.class))).thenReturn(Collections.emptyList());
+
+    ResponseEntity<List<ApiRequestLog>> response = controller.getErrors(30);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEmpty();
+  }
+
+  @Test
+  void shouldSearchByUri() {
+    when(apiRequestLogRepository.findByRequestUri("/orders")).thenReturn(Collections.emptyList());
+
+    ResponseEntity<List<ApiRequestLog>> response = controller.searchByUri("/orders");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void shouldGetByCorrelationId() {
+    ApiRequestLog log = new ApiRequestLog("corr-1", "GET", "/orders", null, "127.0.0.1", null);
+    when(apiRequestLogRepository.findByCorrelationId("corr-1")).thenReturn(log);
+
+    ResponseEntity<ApiRequestLog> response = controller.getByCorrelationId("corr-1");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getCorrelationId()).isEqualTo("corr-1");
+  }
+
+  @Test
+  void shouldReturn404WhenCorrelationIdNotFound() {
+    when(apiRequestLogRepository.findByCorrelationId("nonexistent")).thenReturn(null);
+
+    ResponseEntity<ApiRequestLog> response = controller.getByCorrelationId("nonexistent");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void shouldGetStatsWithLogs() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/orders", null, "127.0.0.1", null);
+    log1.complete(200, 50L);
+    ApiRequestLog log2 = new ApiRequestLog("c2", "POST", "/orders", null, "127.0.0.1", null);
+    log2.complete(500, 120L, "Error");
+    when(apiRequestLogRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Arrays.asList(log1, log2));
+
+    ResponseEntity<Map<String, Object>> response = controller.getStats(60);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    Map<String, Object> stats = response.getBody();
+    assertThat(stats).isNotNull();
+    assertThat(stats.get("totalRequests")).isEqualTo(2);
+    assertThat(stats.get("errorCount")).isEqualTo(1L);
+    assertThat(stats.get("periodMinutes")).isEqualTo(60);
+  }
+
+  @Test
+  void shouldGetStatsWithEmptyLogs() {
+    when(apiRequestLogRepository.findRecentLogs(any(LocalDateTime.class))).thenReturn(Collections.emptyList());
+
+    ResponseEntity<Map<String, Object>> response = controller.getStats(60);
+
+    Map<String, Object> stats = response.getBody();
+    assertThat(stats).isNotNull();
+    assertThat(stats.get("totalRequests")).isEqualTo(0);
+    assertThat(stats.get("errorRate")).isEqualTo(0.0);
+  }
+
+  @Test
+  void shouldCalculateP95Duration() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/a", null, "127.0.0.1", null);
+    log1.complete(200, 10L);
+    ApiRequestLog log2 = new ApiRequestLog("c2", "GET", "/b", null, "127.0.0.1", null);
+    log2.complete(200, 100L);
+    when(apiRequestLogRepository.findRecentLogs(any())).thenReturn(Arrays.asList(log1, log2));
+
+    ResponseEntity<Map<String, Object>> response = controller.getStats(60);
+
+    assertThat(response.getBody()).containsKey("p95DurationMs");
+  }
+
+  @Test
+  void shouldCalculateStatusCodeDistribution() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/a", null, "127.0.0.1", null);
+    log1.complete(200, 10L);
+    ApiRequestLog log2 = new ApiRequestLog("c2", "GET", "/b", null, "127.0.0.1", null);
+    log2.complete(404, 20L);
+    when(apiRequestLogRepository.findRecentLogs(any())).thenReturn(Arrays.asList(log1, log2));
+
+    ResponseEntity<Map<String, Object>> response = controller.getStats(60);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Long> statusDist = (Map<String, Long>) response.getBody().get("statusCodeDistribution");
+    assertThat(statusDist).containsEntry("200", 1L).containsEntry("404", 1L);
+  }
+
+  @Test
+  void shouldHandleLogsWithNullDuration() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/a", null, "127.0.0.1", null);
+    when(apiRequestLogRepository.findRecentLogs(any())).thenReturn(Collections.singletonList(log1));
+
+    ResponseEntity<Map<String, Object>> response = controller.getStats(60);
+
+    assertThat(response.getBody().get("avgDurationMs")).isEqualTo(0.0);
+  }
+
+  @Test
+  void shouldHandleLogsWithNullResponseStatus() {
+    ApiRequestLog log1 = new ApiRequestLog("c1", "GET", "/a", null, "127.0.0.1", null);
+    when(apiRequestLogRepository.findRecentLogs(any())).thenReturn(Collections.singletonList(log1));
+
+    ResponseEntity<Map<String, Object>> response = controller.getStats(60);
+
+    assertThat(response.getBody().get("errorCount")).isEqualTo(0L);
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptorTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptorTest.java
@@ -1,0 +1,129 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApiTrackingInterceptorTest {
+
+  @Mock
+  private ApiRequestLogRepository apiRequestLogRepository;
+
+  private ApiTrackingInterceptor interceptor;
+
+  @BeforeEach
+  void setUp() {
+    interceptor = new ApiTrackingInterceptor(apiRequestLogRepository);
+  }
+
+  @Test
+  void preHandleShouldGenerateCorrelationIdWhenMissing() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/orders/1");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertThat(result).isTrue();
+    assertThat(response.getHeader("X-Correlation-ID")).isNotNull().isNotEmpty();
+  }
+
+  @Test
+  void preHandleShouldUseProvidedCorrelationId() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/orders/1");
+    request.addHeader("X-Correlation-ID", "my-corr-id");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+
+    assertThat(response.getHeader("X-Correlation-ID")).isEqualTo("my-corr-id");
+  }
+
+  @Test
+  void afterCompletionShouldSaveLogEntry() {
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", "/orders");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    response.setStatus(200);
+    when(apiRequestLogRepository.save(any(ApiRequestLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    interceptor.preHandle(request, response, new Object());
+    interceptor.afterCompletion(request, response, new Object(), null);
+
+    ArgumentCaptor<ApiRequestLog> captor = ArgumentCaptor.forClass(ApiRequestLog.class);
+    verify(apiRequestLogRepository).save(captor.capture());
+
+    ApiRequestLog saved = captor.getValue();
+    assertThat(saved.getHttpMethod()).isEqualTo("POST");
+    assertThat(saved.getRequestUri()).isEqualTo("/orders");
+    assertThat(saved.getResponseStatus()).isEqualTo(200);
+    assertThat(saved.getDurationMs()).isNotNull();
+  }
+
+  @Test
+  void afterCompletionShouldRecordErrorMessage() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/orders/1");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    response.setStatus(500);
+    when(apiRequestLogRepository.save(any(ApiRequestLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    interceptor.preHandle(request, response, new Object());
+    interceptor.afterCompletion(request, response, new Object(), new RuntimeException("Server error"));
+
+    ArgumentCaptor<ApiRequestLog> captor = ArgumentCaptor.forClass(ApiRequestLog.class);
+    verify(apiRequestLogRepository).save(captor.capture());
+
+    assertThat(captor.getValue().getErrorMessage()).isEqualTo("Server error");
+  }
+
+  @Test
+  void afterCompletionShouldHandleSaveException() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    when(apiRequestLogRepository.save(any())).thenThrow(new RuntimeException("DB error"));
+
+    interceptor.preHandle(request, response, new Object());
+    interceptor.afterCompletion(request, response, new Object(), null);
+
+    verify(apiRequestLogRepository).save(any());
+  }
+
+  @Test
+  void afterCompletionShouldHandleMissingAttributes() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    interceptor.afterCompletion(request, response, new Object(), null);
+
+    verify(apiRequestLogRepository, never()).save(any());
+  }
+
+  @Test
+  void postHandleShouldDoNothing() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    interceptor.postHandle(request, response, new Object(), null);
+
+    verifyNoInteractions(apiRequestLogRepository);
+  }
+
+  @Test
+  void preHandleShouldGenerateCorrelationIdWhenEmpty() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+    request.addHeader("X-Correlation-ID", "");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+
+    assertThat(response.getHeader("X-Correlation-ID")).isNotEmpty();
+  }
+}

--- a/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/domain/ConsumerServiceTest.java
+++ b/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/domain/ConsumerServiceTest.java
@@ -1,0 +1,80 @@
+package net.chrisrichardson.ftgo.consumerservice.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.domain.Consumer;
+import net.chrisrichardson.ftgo.domain.ConsumerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumerServiceTest {
+
+  @Mock
+  private ConsumerRepository consumerRepository;
+
+  @InjectMocks
+  private ConsumerService consumerService;
+
+  @Test
+  void shouldValidateOrderForConsumer() {
+    Consumer consumer = new Consumer(new PersonName("John", "Doe"));
+    when(consumerRepository.findById(1L)).thenReturn(Optional.of(consumer));
+
+    consumerService.validateOrderForConsumer(1L, new Money("50.00"));
+
+    verify(consumerRepository).findById(1L);
+  }
+
+  @Test
+  void shouldThrowWhenConsumerNotFound() {
+    when(consumerRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> consumerService.validateOrderForConsumer(999L, new Money("50.00")))
+            .isInstanceOf(ConsumerNotFoundException.class);
+  }
+
+  @Test
+  void shouldCreateConsumer() {
+    PersonName name = new PersonName("John", "Doe");
+    Consumer consumer = new Consumer(name);
+    when(consumerRepository.save(any(Consumer.class))).thenReturn(consumer);
+
+    Consumer result = consumerService.create(name);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getName().getFirstName()).isEqualTo("John");
+    verify(consumerRepository).save(any(Consumer.class));
+  }
+
+  @Test
+  void shouldFindConsumerById() {
+    Consumer consumer = new Consumer(new PersonName("John", "Doe"));
+    when(consumerRepository.findById(1L)).thenReturn(Optional.of(consumer));
+
+    Optional<Consumer> result = consumerService.findById(1L);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getName().getFirstName()).isEqualTo("John");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenConsumerNotFound() {
+    when(consumerRepository.findById(999L)).thenReturn(Optional.empty());
+
+    Optional<Consumer> result = consumerService.findById(999L);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/web/ConsumerControllerTest.java
+++ b/ftgo-consumer-service/src/test/java/net/chrisrichardson/ftgo/consumerservice/web/ConsumerControllerTest.java
@@ -1,0 +1,66 @@
+package net.chrisrichardson.ftgo.consumerservice.web;
+
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.consumerservice.api.web.CreateConsumerRequest;
+import net.chrisrichardson.ftgo.consumerservice.api.web.CreateConsumerResponse;
+import net.chrisrichardson.ftgo.consumerservice.domain.ConsumerService;
+import net.chrisrichardson.ftgo.domain.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumerControllerTest {
+
+  @Mock
+  private ConsumerService consumerService;
+
+  @Mock
+  private Consumer mockConsumer;
+
+  @InjectMocks
+  private ConsumerController controller;
+
+  @Test
+  void shouldCreateConsumer() {
+    when(mockConsumer.getId()).thenReturn(1L);
+    when(consumerService.create(any(PersonName.class))).thenReturn(mockConsumer);
+
+    CreateConsumerRequest request = new CreateConsumerRequest(new PersonName("John", "Doe"));
+
+    CreateConsumerResponse response = controller.create(request);
+
+    assertThat(response.getConsumerId()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldGetConsumer() {
+    Consumer consumer = new Consumer(new PersonName("John", "Doe"));
+    when(consumerService.findById(1L)).thenReturn(Optional.of(consumer));
+
+    ResponseEntity<GetConsumerResponse> response = controller.get(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getName().getFirstName()).isEqualTo("John");
+  }
+
+  @Test
+  void shouldReturn404WhenConsumerNotFound() {
+    when(consumerService.findById(999L)).thenReturn(Optional.empty());
+
+    ResponseEntity<GetConsumerResponse> response = controller.get(999L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+}

--- a/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/domain/CourierServiceTest.java
+++ b/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/domain/CourierServiceTest.java
@@ -1,0 +1,100 @@
+package net.chrisrichardson.ftgo.courierservice.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.domain.Courier;
+import net.chrisrichardson.ftgo.domain.CourierRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CourierServiceTest {
+
+  @Mock
+  private CourierRepository courierRepository;
+
+  private CourierService courierService;
+
+  @BeforeEach
+  void setUp() {
+    courierService = new CourierService(courierRepository);
+  }
+
+  @Test
+  void shouldCreateCourier() {
+    PersonName name = new PersonName("John", "Doe");
+    Address address = new Address("1 Main St", null, "Oakland", "CA", "94612");
+    when(courierRepository.save(any(Courier.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    Courier courier = courierService.createCourier(name, address);
+
+    assertThat(courier).isNotNull();
+    assertThat(courier.getName().getFirstName()).isEqualTo("John");
+    verify(courierRepository).save(any(Courier.class));
+  }
+
+  @Test
+  void shouldUpdateAvailabilityToAvailable() {
+    Courier courier = new Courier(new PersonName("John", "Doe"),
+            new Address("1 Main St", null, "Oakland", "CA", "94612"));
+    when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
+
+    courierService.updateAvailability(1L, true);
+
+    assertThat(courier.isAvailable()).isTrue();
+  }
+
+  @Test
+  void shouldUpdateAvailabilityToUnavailable() {
+    Courier courier = new Courier(new PersonName("John", "Doe"),
+            new Address("1 Main St", null, "Oakland", "CA", "94612"));
+    courier.noteAvailable();
+    when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
+
+    courierService.updateAvailability(1L, false);
+
+    assertThat(courier.isAvailable()).isFalse();
+  }
+
+  @Test
+  void shouldFindCourierById() {
+    Courier courier = new Courier(new PersonName("John", "Doe"),
+            new Address("1 Main St", null, "Oakland", "CA", "94612"));
+    when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
+
+    Courier found = courierService.findCourierById(1L);
+
+    assertThat(found).isEqualTo(courier);
+  }
+
+  @Test
+  void shouldUpdateLocation() {
+    Courier courier = new Courier(new PersonName("John", "Doe"),
+            new Address("1 Main St", null, "Oakland", "CA", "94612"));
+    when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
+
+    courierService.updateLocation(1L, 37.8044, -122.2712);
+
+    assertThat(courier.getCurrentLatitude()).isEqualTo(37.8044);
+    assertThat(courier.getCurrentLongitude()).isEqualTo(-122.2712);
+  }
+
+  @Test
+  void shouldThrowWhenUpdatingLocationOfNonExistentCourier() {
+    when(courierRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> courierService.updateLocation(999L, 37.8044, -122.2712))
+            .isInstanceOf(CourierNotFoundException.class);
+  }
+}

--- a/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/web/CourierControllerTest.java
+++ b/ftgo-courier-service/src/test/java/net/chrisrichardson/ftgo/courierservice/web/CourierControllerTest.java
@@ -1,0 +1,104 @@
+package net.chrisrichardson.ftgo.courierservice.web;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.courierservice.api.*;
+import net.chrisrichardson.ftgo.courierservice.domain.CourierService;
+import net.chrisrichardson.ftgo.domain.Courier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CourierControllerTest {
+
+  @Mock
+  private CourierService courierService;
+
+  @Mock
+  private Courier mockCourier;
+
+  private CourierController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new CourierController(courierService);
+  }
+
+  @Test
+  void shouldCreateCourier() {
+    when(mockCourier.getId()).thenReturn(1L);
+    when(courierService.createCourier(any(), any())).thenReturn(mockCourier);
+
+    CreateCourierRequest request = new CreateCourierRequest();
+    request.setName(new PersonName("John", "Doe"));
+    request.setAddress(new Address("1 Main St", null, "Oakland", "CA", "94612"));
+
+    ResponseEntity<CreateCourierResponse> response = controller.create(request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getId()).isEqualTo(1L);
+    verify(courierService).createCourier(any(), any());
+  }
+
+  @Test
+  void shouldUpdateAvailability() {
+    CourierAvailability availability = new CourierAvailability();
+    availability.setAvailable(true);
+
+    ResponseEntity<String> response = controller.updateCourierLocation(1L, availability);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(courierService).updateAvailability(1L, true);
+  }
+
+  @Test
+  void shouldGetCourier() {
+    Courier courier = new Courier(new PersonName("John", "Doe"),
+            new Address("1 Main St", null, "Oakland", "CA", "94612"));
+    when(courierService.findCourierById(1L)).thenReturn(courier);
+
+    ResponseEntity<Courier> response = controller.get(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+  }
+
+  @Test
+  void shouldUpdateLocation() {
+    CourierLocationUpdate update = new CourierLocationUpdate();
+    update.setLatitude(37.8044);
+    update.setLongitude(-122.2712);
+
+    ResponseEntity<String> response = controller.updateLocation(1L, update);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(courierService).updateLocation(1L, 37.8044, -122.2712);
+  }
+
+  @Test
+  void shouldGetWorkload() {
+    when(mockCourier.getId()).thenReturn(1L);
+    when(mockCourier.getActiveDeliveryCount()).thenReturn(2);
+    when(mockCourier.isAvailable()).thenReturn(true);
+    when(mockCourier.getCurrentLatitude()).thenReturn(37.8044);
+    when(mockCourier.getCurrentLongitude()).thenReturn(-122.2712);
+    when(mockCourier.getLastLocationUpdate()).thenReturn(null);
+    when(courierService.findCourierById(1L)).thenReturn(mockCourier);
+
+    ResponseEntity<CourierWorkloadResponse> response = controller.getWorkload(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().isAvailable()).isTrue();
+    assertThat(response.getBody().getActiveDeliveries()).isEqualTo(2);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/ActionTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/ActionTest.java
@@ -1,0 +1,51 @@
+package net.chrisrichardson.ftgo.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActionTest {
+
+  @Test
+  void shouldMakePickupAction() {
+    Restaurant restaurant = new Restaurant(1L, "Test", new RestaurantMenu(Collections.emptyList()));
+    Order order = new Order(1L, restaurant, Collections.emptyList());
+    order.setId(10L);
+
+    Action action = Action.makePickup(order);
+
+    assertThat(action.getType()).isEqualTo(ActionType.PICKUP);
+    assertThat(action.getTime()).isNull();
+  }
+
+  @Test
+  void shouldMakeDropoffAction() {
+    Restaurant restaurant = new Restaurant(1L, "Test", new RestaurantMenu(Collections.emptyList()));
+    Order order = new Order(1L, restaurant, Collections.emptyList());
+    order.setId(10L);
+    LocalDateTime deliveryTime = LocalDateTime.now().plusMinutes(30);
+
+    Action action = Action.makeDropoff(order, deliveryTime);
+
+    assertThat(action.getType()).isEqualTo(ActionType.DROPOFF);
+    assertThat(action.getTime()).isEqualTo(deliveryTime);
+  }
+
+  @Test
+  void shouldCheckActionForOrder() {
+    Restaurant restaurant = new Restaurant(1L, "Test", new RestaurantMenu(Collections.emptyList()));
+    Order order = new Order(1L, restaurant, Collections.emptyList());
+    order.setId(10L);
+
+    Order otherOrder = new Order(2L, restaurant, Collections.emptyList());
+    otherOrder.setId(20L);
+
+    Action action = Action.makePickup(order);
+
+    assertThat(action.actionFor(order)).isTrue();
+    assertThat(action.actionFor(otherOrder)).isFalse();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/ConsumerTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/ConsumerTest.java
@@ -1,0 +1,25 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConsumerTest {
+
+  @Test
+  void shouldCreateConsumer() {
+    Consumer consumer = new Consumer(new PersonName("John", "Doe"));
+
+    assertThat(consumer.getName().getFirstName()).isEqualTo("John");
+    assertThat(consumer.getName().getLastName()).isEqualTo("Doe");
+    assertThat(consumer.getId()).isNull();
+  }
+
+  @Test
+  void shouldValidateOrderByConsumer() {
+    Consumer consumer = new Consumer(new PersonName("John", "Doe"));
+    consumer.validateOrderByConsumer(new Money("100.00"));
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/CourierAssignmentStrategyTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/CourierAssignmentStrategyTest.java
@@ -85,6 +85,20 @@ public class CourierAssignmentStrategyTest {
   }
 
   @Test
+  public void shouldFallbackToLeastLoadedWhenAllAtMaxCapacity() {
+    Courier maxed1 = makeCourier("Maxed1", 37.8045, -122.2713);
+    Courier maxed2 = makeCourier("Maxed2", 37.8046, -122.2714);
+
+    addFakeDeliveries(maxed1, 5);
+    addFakeDeliveries(maxed2, 5);
+
+    Courier assigned = strategy.assignCourier(Arrays.asList(maxed1, maxed2), order);
+
+    // Should fall back to load-balanced assignment (least loaded)
+    assertNotNull(assigned);
+  }
+
+  @Test
   public void shouldHandleSingleCourier() {
     Courier onlyCourier = makeCourier("Only", 37.8050, -122.2720);
 

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/CourierTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/CourierTest.java
@@ -1,0 +1,163 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.PersonName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CourierTest {
+
+  private Courier courier;
+  private Address address;
+
+  @BeforeEach
+  void setUp() {
+    address = new Address("1 Main St", null, "Oakland", "CA", "94612", 37.8044, -122.2712);
+    courier = new Courier(new PersonName("John", "Doe"), address);
+  }
+
+  @Test
+  void shouldCreateCourierWithAddress() {
+    assertThat(courier.getName().getFirstName()).isEqualTo("John");
+    assertThat(courier.getName().getLastName()).isEqualTo("Doe");
+    assertThat(courier.getAddress()).isEqualTo(address);
+    assertThat(courier.getCurrentLatitude()).isEqualTo(37.8044);
+    assertThat(courier.getCurrentLongitude()).isEqualTo(-122.2712);
+  }
+
+  @Test
+  void shouldCreateCourierWithoutLocation() {
+    Address noLocAddr = new Address("1 Main St", null, "Oakland", "CA", "94612");
+    Courier noLocCourier = new Courier(new PersonName("Jane", "Doe"), noLocAddr);
+
+    assertThat(noLocCourier.getCurrentLatitude()).isNull();
+    assertThat(noLocCourier.getCurrentLongitude()).isNull();
+  }
+
+  @Test
+  void shouldCreateCourierWithNullAddress() {
+    Courier nullAddrCourier = new Courier(new PersonName("Test", "User"), null);
+
+    assertThat(nullAddrCourier.getAddress()).isNull();
+    assertThat(nullAddrCourier.getCurrentLatitude()).isNull();
+  }
+
+  @Test
+  void shouldDefaultToNotAvailable() {
+    assertThat(courier.isAvailable()).isFalse();
+  }
+
+  @Test
+  void shouldNoteAvailable() {
+    courier.noteAvailable();
+    assertThat(courier.isAvailable()).isTrue();
+  }
+
+  @Test
+  void shouldNoteUnavailable() {
+    courier.noteAvailable();
+    courier.noteUnavailable();
+    assertThat(courier.isAvailable()).isFalse();
+  }
+
+  @Test
+  void shouldUpdateLocation() {
+    courier.updateLocation(37.9000, -122.4000);
+
+    assertThat(courier.getCurrentLatitude()).isEqualTo(37.9000);
+    assertThat(courier.getCurrentLongitude()).isEqualTo(-122.4000);
+    assertThat(courier.getLastLocationUpdate()).isNotNull();
+  }
+
+  @Test
+  void shouldHasLocationReturnTrueWhenSet() {
+    assertThat(courier.hasLocation()).isTrue();
+  }
+
+  @Test
+  void shouldHasLocationReturnFalseWhenNotSet() {
+    Courier noLocCourier = new Courier(new PersonName("Jane", "Doe"),
+            new Address("1 Main St", null, "Oakland", "CA", "94612"));
+    assertThat(noLocCourier.hasLocation()).isFalse();
+  }
+
+  @Test
+  void shouldAddAction() {
+    Restaurant restaurant = new Restaurant(1L, "Test", new RestaurantMenu(Collections.emptyList()));
+    Order order = new Order(1L, restaurant, Collections.emptyList());
+    order.setId(1L);
+
+    courier.addAction(Action.makePickup(order));
+
+    assertThat(courier.getPlan().getActions()).hasSize(1);
+    assertThat(courier.getPlan().getActions().get(0).getType()).isEqualTo(ActionType.PICKUP);
+  }
+
+  @Test
+  void shouldCancelDelivery() {
+    Restaurant restaurant = new Restaurant(1L, "Test", new RestaurantMenu(Collections.emptyList()));
+    Order order = new Order(1L, restaurant, Collections.emptyList());
+    order.setId(1L);
+
+    courier.addAction(Action.makePickup(order));
+    courier.addAction(Action.makeDropoff(order, LocalDateTime.now().plusMinutes(30)));
+
+    courier.cancelDelivery(order);
+
+    assertThat(courier.getPlan().getActions()).isEmpty();
+  }
+
+  @Test
+  void shouldGetActionsForDelivery() {
+    Restaurant restaurant = new Restaurant(1L, "Test", new RestaurantMenu(Collections.emptyList()));
+    Order order1 = new Order(1L, restaurant, Collections.emptyList());
+    order1.setId(1L);
+    Order order2 = new Order(2L, restaurant, Collections.emptyList());
+    order2.setId(2L);
+
+    courier.addAction(Action.makePickup(order1));
+    courier.addAction(Action.makePickup(order2));
+    courier.addAction(Action.makeDropoff(order1, LocalDateTime.now().plusMinutes(30)));
+
+    List<Action> actionsForOrder1 = courier.actionsForDelivery(order1);
+    assertThat(actionsForOrder1).hasSize(2);
+  }
+
+  @Test
+  void shouldGetActiveDeliveryCount() {
+    Restaurant restaurant = new Restaurant(1L, "Test", new RestaurantMenu(Collections.emptyList()));
+    Order order1 = new Order(1L, restaurant, Collections.emptyList());
+    order1.setId(1L);
+    Order order2 = new Order(2L, restaurant, Collections.emptyList());
+    order2.setId(2L);
+
+    courier.addAction(Action.makePickup(order1));
+    courier.addAction(Action.makePickup(order2));
+    courier.addAction(Action.makeDropoff(order1, LocalDateTime.now().plusMinutes(30)));
+
+    assertThat(courier.getActiveDeliveryCount()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldGetZeroActiveDeliveriesForNewCourier() {
+    assertThat(courier.getActiveDeliveryCount()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldGetIdReturnNull() {
+    assertThat(courier.getId()).isNull();
+  }
+
+  @Test
+  void shouldCreateDefaultCourier() {
+    Courier defaultCourier = new Courier();
+    assertThat(defaultCourier.isAvailable()).isFalse();
+    assertThat(defaultCourier.getActiveDeliveryCount()).isEqualTo(0);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/LineItemQuantityChangeTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/LineItemQuantityChangeTest.java
@@ -1,0 +1,22 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LineItemQuantityChangeTest {
+
+  @Test
+  void shouldStoreQuantityChangeDetails() {
+    Money current = new Money("50.00");
+    Money newTotal = new Money("70.00");
+    Money delta = new Money("20.00");
+
+    LineItemQuantityChange change = new LineItemQuantityChange(current, newTotal, delta);
+
+    assertThat(change.getCurrentOrderTotal()).isEqualTo(current);
+    assertThat(change.getNewOrderTotal()).isEqualTo(newTotal);
+    assertThat(change.getDelta()).isEqualTo(delta);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/MenuItemTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/MenuItemTest.java
@@ -1,0 +1,47 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MenuItemTest {
+
+  @Test
+  void shouldCreateMenuItem() {
+    MenuItem item = new MenuItem("1", "Chicken", new Money("10.00"));
+
+    assertThat(item.getId()).isEqualTo("1");
+    assertThat(item.getName()).isEqualTo("Chicken");
+    assertThat(item.getPrice()).isEqualTo(new Money("10.00"));
+  }
+
+  @Test
+  void shouldSupportSetters() {
+    MenuItem item = new MenuItem("1", "Chicken", new Money("10.00"));
+    item.setId("2");
+    item.setName("Rice");
+    item.setPrice(new Money("5.00"));
+
+    assertThat(item.getId()).isEqualTo("2");
+    assertThat(item.getName()).isEqualTo("Rice");
+    assertThat(item.getPrice()).isEqualTo(new Money("5.00"));
+  }
+
+  @Test
+  void shouldHaveEqualsAndHashCode() {
+    MenuItem item1 = new MenuItem("1", "Chicken", new Money("10.00"));
+    MenuItem item2 = new MenuItem("1", "Chicken", new Money("10.00"));
+    MenuItem item3 = new MenuItem("2", "Rice", new Money("5.00"));
+
+    assertThat(item1).isEqualTo(item2);
+    assertThat(item1.hashCode()).isEqualTo(item2.hashCode());
+    assertThat(item1).isNotEqualTo(item3);
+  }
+
+  @Test
+  void shouldHaveToString() {
+    MenuItem item = new MenuItem("1", "Chicken", new Money("10.00"));
+    assertThat(item.toString()).isNotEmpty();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/NoCourierAvailableExceptionTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/NoCourierAvailableExceptionTest.java
@@ -1,0 +1,14 @@
+package net.chrisrichardson.ftgo.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoCourierAvailableExceptionTest {
+
+  @Test
+  void shouldHaveMessage() {
+    NoCourierAvailableException ex = new NoCourierAvailableException();
+    assertThat(ex.getMessage()).contains("No courier available");
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderLineItemTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderLineItemTest.java
@@ -1,0 +1,73 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderLineItemTest {
+
+  @Test
+  void shouldCreateOrderLineItem() {
+    OrderLineItem item = new OrderLineItem("item1", "Chicken", new Money("10.00"), 3);
+
+    assertThat(item.getMenuItemId()).isEqualTo("item1");
+    assertThat(item.getName()).isEqualTo("Chicken");
+    assertThat(item.getPrice()).isEqualTo(new Money("10.00"));
+    assertThat(item.getQuantity()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldCalculateTotal() {
+    OrderLineItem item = new OrderLineItem("item1", "Chicken", new Money("10.00"), 3);
+
+    assertThat(item.getTotal()).isEqualTo(new Money("30.00"));
+  }
+
+  @Test
+  void shouldCalculateDeltaForChangedQuantity() {
+    OrderLineItem item = new OrderLineItem("item1", "Chicken", new Money("10.00"), 3);
+
+    Money delta = item.deltaForChangedQuantity(5);
+    assertThat(delta).isEqualTo(new Money("20.00"));
+  }
+
+  @Test
+  void shouldCalculateNegativeDeltaForDecreasedQuantity() {
+    OrderLineItem item = new OrderLineItem("item1", "Chicken", new Money("10.00"), 5);
+
+    Money delta = item.deltaForChangedQuantity(2);
+    assertThat(delta).isEqualTo(new Money("-30.00"));
+  }
+
+  @Test
+  void shouldSupportSetters() {
+    OrderLineItem item = new OrderLineItem();
+    item.setMenuItemId("item2");
+    item.setName("Pasta");
+    item.setPrice(new Money("15.00"));
+    item.setQuantity(2);
+
+    assertThat(item.getMenuItemId()).isEqualTo("item2");
+    assertThat(item.getName()).isEqualTo("Pasta");
+    assertThat(item.getPrice()).isEqualTo(new Money("15.00"));
+    assertThat(item.getQuantity()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldHaveToString() {
+    OrderLineItem item = new OrderLineItem("item1", "Chicken", new Money("10.00"), 3);
+    assertThat(item.toString()).isNotEmpty();
+  }
+
+  @Test
+  void shouldHaveEqualsAndHashCode() {
+    OrderLineItem item1 = new OrderLineItem("item1", "Chicken", new Money("10.00"), 3);
+    OrderLineItem item2 = new OrderLineItem("item1", "Chicken", new Money("10.00"), 3);
+    OrderLineItem item3 = new OrderLineItem("item2", "Pasta", new Money("15.00"), 2);
+
+    assertThat(item1).isEqualTo(item2);
+    assertThat(item1.hashCode()).isEqualTo(item2.hashCode());
+    assertThat(item1).isNotEqualTo(item3);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderLineItemsTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderLineItemsTest.java
@@ -1,0 +1,81 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrderLineItemsTest {
+
+  private OrderLineItems orderLineItems;
+
+  @BeforeEach
+  void setUp() {
+    List<OrderLineItem> items = Arrays.asList(
+            new OrderLineItem("item1", "Chicken", new Money("10.00"), 2),
+            new OrderLineItem("item2", "Rice", new Money("5.00"), 3)
+    );
+    orderLineItems = new OrderLineItems(items);
+  }
+
+  @Test
+  void shouldCalculateOrderTotal() {
+    Money total = orderLineItems.orderTotal();
+    assertThat(total).isEqualTo(new Money("35.00"));
+  }
+
+  @Test
+  void shouldGetLineItems() {
+    assertThat(orderLineItems.getLineItems()).hasSize(2);
+  }
+
+  @Test
+  void shouldSetLineItems() {
+    List<OrderLineItem> newItems = Collections.singletonList(
+            new OrderLineItem("item3", "Soup", new Money("7.00"), 1));
+    orderLineItems.setLineItems(newItems);
+    assertThat(orderLineItems.getLineItems()).hasSize(1);
+  }
+
+  @Test
+  void shouldCalculateLineItemQuantityChange() {
+    Map<String, Integer> revisedQuantities = new HashMap<>();
+    revisedQuantities.put("item1", 4);
+    OrderRevision revision = new OrderRevision(Optional.empty(), revisedQuantities);
+
+    LineItemQuantityChange change = orderLineItems.lineItemQuantityChange(revision);
+
+    assertThat(change.getCurrentOrderTotal()).isEqualTo(new Money("35.00"));
+    assertThat(change.getDelta()).isEqualTo(new Money("20.00"));
+    assertThat(change.getNewOrderTotal()).isEqualTo(new Money("55.00"));
+  }
+
+  @Test
+  void shouldUpdateLineItems() {
+    Map<String, Integer> revisedQuantities = new HashMap<>();
+    revisedQuantities.put("item1", 5);
+    revisedQuantities.put("item2", 1);
+    OrderRevision revision = new OrderRevision(Optional.empty(), revisedQuantities);
+
+    orderLineItems.updateLineItems(revision);
+
+    assertThat(orderLineItems.getLineItems().get(0).getQuantity()).isEqualTo(5);
+    assertThat(orderLineItems.getLineItems().get(1).getQuantity()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldFindOrderLineItem() {
+    OrderLineItem found = orderLineItems.findOrderLineItem("item1");
+    assertThat(found.getName()).isEqualTo("Chicken");
+  }
+
+  @Test
+  void shouldThrowWhenLineItemNotFound() {
+    assertThatThrownBy(() -> orderLineItems.findOrderLineItem("nonexistent"))
+            .isInstanceOf(NoSuchElementException.class);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderMinimumNotMetExceptionTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderMinimumNotMetExceptionTest.java
@@ -1,0 +1,14 @@
+package net.chrisrichardson.ftgo.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderMinimumNotMetExceptionTest {
+
+  @Test
+  void shouldBeRuntimeException() {
+    OrderMinimumNotMetException ex = new OrderMinimumNotMetException();
+    assertThat(ex).isInstanceOf(RuntimeException.class);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderRevisionTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderRevisionTest.java
@@ -1,0 +1,45 @@
+package net.chrisrichardson.ftgo.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderRevisionTest {
+
+  @Test
+  void shouldCreateOrderRevision() {
+    Map<String, Integer> quantities = new HashMap<>();
+    quantities.put("item1", 3);
+    OrderRevision revision = new OrderRevision(Optional.empty(), quantities);
+
+    assertThat(revision.getDeliveryInformation()).isEmpty();
+    assertThat(revision.getRevisedLineItemQuantities()).containsEntry("item1", 3);
+  }
+
+  @Test
+  void shouldCreateWithDeliveryInformation() {
+    DeliveryInformation di = new DeliveryInformation();
+    Map<String, Integer> quantities = new HashMap<>();
+    OrderRevision revision = new OrderRevision(Optional.of(di), quantities);
+
+    assertThat(revision.getDeliveryInformation()).isPresent();
+  }
+
+  @Test
+  void shouldSupportSetters() {
+    Map<String, Integer> quantities = new HashMap<>();
+    OrderRevision revision = new OrderRevision(Optional.empty(), quantities);
+
+    Map<String, Integer> newQuantities = new HashMap<>();
+    newQuantities.put("item2", 5);
+    revision.setRevisedLineItemQuantities(newQuantities);
+    revision.setDeliveryInformation(Optional.of(new DeliveryInformation()));
+
+    assertThat(revision.getRevisedLineItemQuantities()).containsEntry("item2", 5);
+    assertThat(revision.getDeliveryInformation()).isPresent();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/OrderTest.java
@@ -1,0 +1,234 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.UnsupportedStateTransitionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrderTest {
+
+  private Restaurant restaurant;
+  private Order order;
+
+  @BeforeEach
+  void setUp() {
+    restaurant = new Restaurant(1L, "Test Restaurant",
+            new RestaurantMenu(Collections.singletonList(
+                    new MenuItem("item1", "Chicken", new Money("10.00")))));
+    order = new Order(100L, restaurant,
+            Collections.singletonList(new OrderLineItem("item1", "Chicken", new Money("10.00"), 2)));
+  }
+
+  @Test
+  void shouldCreateOrderInApprovedState() {
+    assertThat(order.getOrderState()).isEqualTo(OrderState.APPROVED);
+    assertThat(order.getConsumerId()).isEqualTo(100L);
+    assertThat(order.getRestaurant()).isEqualTo(restaurant);
+    assertThat(order.getLineItems()).hasSize(1);
+  }
+
+  @Test
+  void shouldCalculateOrderTotal() {
+    assertThat(order.getOrderTotal()).isEqualTo(new Money("20.00"));
+  }
+
+  @Test
+  void shouldCancelApprovedOrder() {
+    order.cancel();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.CANCELLED);
+  }
+
+  @Test
+  void shouldNotCancelNonApprovedOrder() {
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+
+    assertThatThrownBy(() -> order.cancel())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  void shouldAcceptTicketWithFutureReadyBy() {
+    LocalDateTime readyBy = LocalDateTime.now().plusHours(1);
+    order.acceptTicket(readyBy);
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+  }
+
+  @Test
+  void shouldThrowWhenAcceptingNonApprovedOrder() {
+    order.cancel();
+
+    assertThatThrownBy(() -> order.acceptTicket(LocalDateTime.now().plusHours(1)))
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  void shouldTransitionToPreparingFromAccepted() {
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PREPARING);
+  }
+
+  @Test
+  void shouldNotPrepareFromApproved() {
+    assertThatThrownBy(() -> order.notePreparing())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  void shouldTransitionToReadyForPickupFromPreparing() {
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+    order.noteReadyForPickup();
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.READY_FOR_PICKUP);
+  }
+
+  @Test
+  void shouldNotReadyForPickupFromAccepted() {
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+
+    assertThatThrownBy(() -> order.noteReadyForPickup())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  void shouldTransitionToPickedUpFromReadyForPickup() {
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    order.notePickedUp();
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PICKED_UP);
+  }
+
+  @Test
+  void shouldNotPickUpFromPreparing() {
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+
+    assertThatThrownBy(() -> order.notePickedUp())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  void shouldTransitionToDeliveredFromPickedUp() {
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    order.notePickedUp();
+    order.noteDelivered();
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.DELIVERED);
+  }
+
+  @Test
+  void shouldNotDeliverFromReadyForPickup() {
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+    order.noteReadyForPickup();
+
+    assertThatThrownBy(() -> order.noteDelivered())
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  void shouldSetAndGetId() {
+    order.setId(42L);
+    assertThat(order.getId()).isEqualTo(42L);
+  }
+
+  @Test
+  void shouldGetVersion() {
+    assertThat(order.getVersion()).isNull();
+  }
+
+  @Test
+  void shouldScheduleWithCourier() {
+    Courier courier = new Courier();
+    order.schedule(courier);
+
+    assertThat(order.getAssignedCourier()).isEqualTo(courier);
+  }
+
+  @Test
+  void shouldReviseOrderWithNewQuantities() {
+    Order bigOrder = new Order(100L, restaurant,
+            Collections.singletonList(new OrderLineItem("item1", "Chicken", new Money("10.00"), 5)));
+
+    Map<String, Integer> revisedQuantities = new HashMap<>();
+    revisedQuantities.put("item1", 3);
+    OrderRevision revision = new OrderRevision(Optional.empty(), revisedQuantities);
+
+    bigOrder.revise(revision);
+
+    assertThat(bigOrder.getLineItems().get(0).getQuantity()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldReviseOrderWithDeliveryInformation() {
+    Order bigOrder = new Order(100L, restaurant,
+            Collections.singletonList(new OrderLineItem("item1", "Chicken", new Money("10.00"), 5)));
+
+    DeliveryInformation di = new DeliveryInformation();
+    Map<String, Integer> revisedQuantities = new HashMap<>();
+    revisedQuantities.put("item1", 3);
+    OrderRevision revision = new OrderRevision(Optional.of(di), revisedQuantities);
+
+    bigOrder.revise(revision);
+
+    assertThat(bigOrder.getLineItems().get(0).getQuantity()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldThrowWhenRevisingNonApprovedOrder() {
+    order.cancel();
+
+    Map<String, Integer> revisedQuantities = new HashMap<>();
+    revisedQuantities.put("item1", 3);
+    OrderRevision revision = new OrderRevision(Optional.empty(), revisedQuantities);
+
+    assertThatThrownBy(() -> order.revise(revision))
+            .isInstanceOf(UnsupportedStateTransitionException.class);
+  }
+
+  @Test
+  void shouldThrowWhenReadyByIsNotInFuture() {
+    assertThatThrownBy(() -> order.acceptTicket(LocalDateTime.now().minusHours(1)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("readyBy is not in the future");
+  }
+
+  @Test
+  void shouldCompleteFullOrderLifecycle() {
+    assertThat(order.getOrderState()).isEqualTo(OrderState.APPROVED);
+
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+
+    order.notePreparing();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PREPARING);
+
+    order.noteReadyForPickup();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.READY_FOR_PICKUP);
+
+    order.notePickedUp();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PICKED_UP);
+
+    order.noteDelivered();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.DELIVERED);
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/PaymentInformationTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/PaymentInformationTest.java
@@ -1,0 +1,14 @@
+package net.chrisrichardson.ftgo.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PaymentInformationTest {
+
+  @Test
+  void shouldConstruct() {
+    PaymentInformation payment = new PaymentInformation();
+    assertThat(payment).isNotNull();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/PlanTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/PlanTest.java
@@ -1,0 +1,70 @@
+package net.chrisrichardson.ftgo.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlanTest {
+
+  private Plan plan;
+  private Order order1;
+  private Order order2;
+
+  @BeforeEach
+  void setUp() {
+    plan = new Plan();
+    Restaurant restaurant = new Restaurant(1L, "Test", new RestaurantMenu(Collections.emptyList()));
+    order1 = new Order(1L, restaurant, Collections.emptyList());
+    order1.setId(1L);
+    order2 = new Order(2L, restaurant, Collections.emptyList());
+    order2.setId(2L);
+  }
+
+  @Test
+  void shouldStartEmpty() {
+    assertThat(plan.getActions()).isEmpty();
+  }
+
+  @Test
+  void shouldAddAction() {
+    plan.add(Action.makePickup(order1));
+    assertThat(plan.getActions()).hasSize(1);
+  }
+
+  @Test
+  void shouldRemoveDeliveryForOrder() {
+    plan.add(Action.makePickup(order1));
+    plan.add(Action.makeDropoff(order1, LocalDateTime.now().plusMinutes(30)));
+    plan.add(Action.makePickup(order2));
+
+    plan.removeDelivery(order1);
+
+    assertThat(plan.getActions()).hasSize(1);
+    assertThat(plan.getActions().get(0).actionFor(order2)).isTrue();
+  }
+
+  @Test
+  void shouldGetActionsForDelivery() {
+    plan.add(Action.makePickup(order1));
+    plan.add(Action.makePickup(order2));
+    plan.add(Action.makeDropoff(order1, LocalDateTime.now().plusMinutes(30)));
+
+    List<Action> actionsForOrder1 = plan.actionsForDelivery(order1);
+
+    assertThat(actionsForOrder1).hasSize(2);
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoActionsForOrder() {
+    plan.add(Action.makePickup(order1));
+
+    List<Action> actions = plan.actionsForDelivery(order2);
+
+    assertThat(actions).isEmpty();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/RestaurantMenuTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/RestaurantMenuTest.java
@@ -1,0 +1,49 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestaurantMenuTest {
+
+  @Test
+  void shouldCreateMenuWithItems() {
+    MenuItem item = new MenuItem("1", "Chicken", new Money("10.00"));
+    RestaurantMenu menu = new RestaurantMenu(Collections.singletonList(item));
+
+    assertThat(menu.getMenuItems()).hasSize(1);
+    assertThat(menu.getMenuItems().get(0).getName()).isEqualTo("Chicken");
+  }
+
+  @Test
+  void shouldSetMenuItems() {
+    RestaurantMenu menu = new RestaurantMenu(Collections.emptyList());
+    List<MenuItem> newItems = Arrays.asList(
+            new MenuItem("1", "Chicken", new Money("10.00")),
+            new MenuItem("2", "Rice", new Money("5.00")));
+    menu.setMenuItems(newItems);
+
+    assertThat(menu.getMenuItems()).hasSize(2);
+  }
+
+  @Test
+  void shouldHaveEqualsAndHashCode() {
+    MenuItem item = new MenuItem("1", "Chicken", new Money("10.00"));
+    RestaurantMenu menu1 = new RestaurantMenu(Collections.singletonList(item));
+    RestaurantMenu menu2 = new RestaurantMenu(Collections.singletonList(item));
+
+    assertThat(menu1).isEqualTo(menu2);
+    assertThat(menu1.hashCode()).isEqualTo(menu2.hashCode());
+  }
+
+  @Test
+  void shouldHaveToString() {
+    RestaurantMenu menu = new RestaurantMenu(Collections.emptyList());
+    assertThat(menu.toString()).isNotEmpty();
+  }
+}

--- a/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/RestaurantTest.java
+++ b/ftgo-domain/src/test/java/net/chrisrichardson/ftgo/domain/RestaurantTest.java
@@ -1,0 +1,78 @@
+package net.chrisrichardson.ftgo.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RestaurantTest {
+
+  @Test
+  void shouldCreateRestaurantWithNameAndMenu() {
+    MenuItem item = new MenuItem("1", "Chicken", new Money("10.00"));
+    RestaurantMenu menu = new RestaurantMenu(Collections.singletonList(item));
+
+    Restaurant restaurant = new Restaurant(1L, "Ajanta", menu);
+
+    assertThat(restaurant.getId()).isEqualTo(1L);
+    assertThat(restaurant.getName()).isEqualTo("Ajanta");
+  }
+
+  @Test
+  void shouldCreateRestaurantWithAddress() {
+    Address address = new Address("1 Main St", null, "Oakland", "CA", "94612");
+    RestaurantMenu menu = new RestaurantMenu(Collections.emptyList());
+
+    Restaurant restaurant = new Restaurant("Ajanta", address, menu);
+
+    assertThat(restaurant.getName()).isEqualTo("Ajanta");
+    assertThat(restaurant.getAddress()).isEqualTo(address);
+  }
+
+  @Test
+  void shouldFindMenuItem() {
+    MenuItem item1 = new MenuItem("1", "Chicken", new Money("10.00"));
+    MenuItem item2 = new MenuItem("2", "Rice", new Money("5.00"));
+    RestaurantMenu menu = new RestaurantMenu(Arrays.asList(item1, item2));
+
+    Restaurant restaurant = new Restaurant(1L, "Test", menu);
+
+    Optional<MenuItem> found = restaurant.findMenuItem("1");
+    assertThat(found).isPresent();
+    assertThat(found.get().getName()).isEqualTo("Chicken");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenMenuItemNotFound() {
+    RestaurantMenu menu = new RestaurantMenu(Collections.singletonList(
+            new MenuItem("1", "Chicken", new Money("10.00"))));
+    Restaurant restaurant = new Restaurant(1L, "Test", menu);
+
+    assertThat(restaurant.findMenuItem("999")).isEmpty();
+  }
+
+  @Test
+  void shouldSetIdAndName() {
+    Restaurant restaurant = new Restaurant();
+    restaurant.setId(42L);
+    restaurant.setName("Updated");
+
+    assertThat(restaurant.getId()).isEqualTo(42L);
+    assertThat(restaurant.getName()).isEqualTo("Updated");
+  }
+
+  @Test
+  void shouldThrowOnReviseMenu() {
+    Restaurant restaurant = new Restaurant(1L, "Test",
+            new RestaurantMenu(Collections.emptyList()));
+
+    assertThatThrownBy(() -> restaurant.reviseMenu(new RestaurantMenu(Collections.emptyList())))
+            .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/OptimisticOfflineLockExceptionTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/OptimisticOfflineLockExceptionTest.java
@@ -1,0 +1,14 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OptimisticOfflineLockExceptionTest {
+
+  @Test
+  void shouldBeRuntimeException() {
+    OptimisticOfflineLockException ex = new OptimisticOfflineLockException();
+    assertThat(ex).isInstanceOf(RuntimeException.class);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/OrderServiceTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/OrderServiceTest.java
@@ -1,0 +1,316 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.consumerservice.domain.ConsumerService;
+import net.chrisrichardson.ftgo.domain.*;
+import net.chrisrichardson.ftgo.orderservice.web.MenuItemIdAndQuantity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+  @Mock
+  private OrderRepository orderRepository;
+
+  @Mock
+  private RestaurantRepository restaurantRepository;
+
+  @Mock
+  private MeterRegistry meterRegistry;
+
+  @Mock
+  private ConsumerService consumerService;
+
+  @Mock
+  private CourierRepository courierRepository;
+
+  @Mock
+  private CourierAssignmentStrategy courierAssignmentStrategy;
+
+  @Mock
+  private Counter counter;
+
+  private OrderService orderService;
+
+  private Restaurant restaurant;
+
+  @BeforeEach
+  void setUp() {
+    orderService = new OrderService(orderRepository, restaurantRepository,
+            Optional.of(meterRegistry), consumerService, courierRepository, courierAssignmentStrategy);
+
+    MenuItem menuItem = new MenuItem("1", "Chicken", new Money("10.00"));
+    restaurant = new Restaurant(1L, "Ajanta", new RestaurantMenu(Collections.singletonList(menuItem)));
+  }
+
+  @Test
+  void shouldCreateOrder() {
+    when(restaurantRepository.findById(1L)).thenReturn(Optional.of(restaurant));
+    when(orderRepository.save(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(meterRegistry.counter(anyString())).thenReturn(counter);
+
+    List<MenuItemIdAndQuantity> lineItems = Collections.singletonList(
+            new MenuItemIdAndQuantity("1", 2));
+
+    Order order = orderService.createOrder(100L, 1L, lineItems);
+
+    assertThat(order).isNotNull();
+    assertThat(order.getOrderState()).isEqualTo(OrderState.APPROVED);
+    assertThat(order.getConsumerId()).isEqualTo(100L);
+    verify(orderRepository).save(any(Order.class));
+    verify(consumerService).validateOrderForConsumer(eq(100L), any(Money.class));
+  }
+
+  @Test
+  void shouldThrowWhenRestaurantNotFound() {
+    when(restaurantRepository.findById(999L)).thenReturn(Optional.empty());
+
+    List<MenuItemIdAndQuantity> lineItems = Collections.singletonList(
+            new MenuItemIdAndQuantity("1", 2));
+
+    assertThatThrownBy(() -> orderService.createOrder(100L, 999L, lineItems))
+            .isInstanceOf(RestaurantNotFoundException.class);
+  }
+
+  @Test
+  void shouldThrowWhenInvalidMenuItemId() {
+    when(restaurantRepository.findById(1L)).thenReturn(Optional.of(restaurant));
+
+    List<MenuItemIdAndQuantity> lineItems = Collections.singletonList(
+            new MenuItemIdAndQuantity("invalid", 2));
+
+    assertThatThrownBy(() -> orderService.createOrder(100L, 1L, lineItems))
+            .isInstanceOf(InvalidMenuItemIdException.class);
+  }
+
+  @Test
+  void shouldCancelOrder() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    Order cancelled = orderService.cancel(1L);
+
+    assertThat(cancelled.getOrderState()).isEqualTo(OrderState.CANCELLED);
+  }
+
+  @Test
+  void shouldThrowWhenCancellingNonExistentOrder() {
+    when(orderRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> orderService.cancel(999L))
+            .isInstanceOf(OrderNotFoundException.class);
+  }
+
+  @Test
+  void shouldReviseOrder() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 5)));
+    order.setId(1L);
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    Map<String, Integer> revised = new HashMap<>();
+    revised.put("1", 3);
+    OrderRevision revision = new OrderRevision(Optional.empty(), revised);
+
+    Order result = orderService.reviseOrder(1L, revision);
+
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  void shouldAcceptOrderAndScheduleDelivery() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    Address addr = new Address("1 Main", null, "Oakland", "CA", "94612", 37.8, -122.2);
+    Courier courier = new Courier(new PersonName("John", "Doe"), addr);
+    when(courierRepository.findAllAvailable()).thenReturn(Collections.singletonList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+    when(meterRegistry.counter(anyString())).thenReturn(counter);
+
+    LocalDateTime readyBy = LocalDateTime.now().plusHours(1);
+    orderService.accept(1L, readyBy);
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.ACCEPTED);
+    assertThat(order.getAssignedCourier()).isEqualTo(courier);
+  }
+
+  @Test
+  void shouldNotePreparing() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    orderService.notePreparing(1L);
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PREPARING);
+  }
+
+  @Test
+  void shouldNoteReadyForPickup() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    orderService.noteReadyForPickup(1L);
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.READY_FOR_PICKUP);
+  }
+
+  @Test
+  void shouldNotePickedUp() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    orderService.notePickedUp(1L);
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.PICKED_UP);
+  }
+
+  @Test
+  void shouldNoteDelivered() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+    order.notePreparing();
+    order.noteReadyForPickup();
+    order.notePickedUp();
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    orderService.noteDelivered(1L);
+
+    assertThat(order.getOrderState()).isEqualTo(OrderState.DELIVERED);
+  }
+
+  @Test
+  void shouldCreateOrderWithoutMeterRegistry() {
+    OrderService serviceNoMetrics = new OrderService(orderRepository, restaurantRepository,
+            Optional.empty(), consumerService, courierRepository, courierAssignmentStrategy);
+
+    when(restaurantRepository.findById(1L)).thenReturn(Optional.of(restaurant));
+    when(orderRepository.save(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    List<MenuItemIdAndQuantity> lineItems = Collections.singletonList(
+            new MenuItemIdAndQuantity("1", 2));
+
+    Order order = serviceNoMetrics.createOrder(100L, 1L, lineItems);
+    assertThat(order).isNotNull();
+  }
+
+  @Test
+  void shouldScheduleDeliveryWithLocationData() {
+    Address restaurantAddr = new Address("1 Main", null, "Oakland", "CA", "94612", 37.8044, -122.2712);
+    Restaurant locatedRestaurant = new Restaurant("Test", restaurantAddr,
+            new RestaurantMenu(Collections.singletonList(new MenuItem("1", "Chicken", new Money("10.00")))));
+    Order order = new Order(100L, locatedRestaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+
+    Address courierAddr = new Address("2 Oak", null, "Oakland", "CA", "94612", 37.81, -122.28);
+    Courier courier = new Courier(new PersonName("Jane", "Doe"), courierAddr);
+    courier.updateLocation(37.81, -122.28);
+    when(courierRepository.findAllAvailable()).thenReturn(Collections.singletonList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+    when(meterRegistry.counter(anyString())).thenReturn(counter);
+
+    LocalDateTime readyBy = LocalDateTime.now().plusHours(1);
+    orderService.scheduleDelivery(order, readyBy);
+
+    assertThat(order.getAssignedCourier()).isEqualTo(courier);
+    assertThat(courier.getPlan().getActions()).hasSize(2);
+  }
+
+  @Test
+  void shouldScheduleDeliveryWhenReadyByIsBeforePickupArrival() {
+    Address restaurantAddr = new Address("1 Main", null, "San Francisco", "CA", "94102", 37.7749, -122.4194);
+    Restaurant farRestaurant = new Restaurant("Far Restaurant", restaurantAddr,
+            new RestaurantMenu(Collections.singletonList(new MenuItem("1", "Chicken", new Money("10.00")))));
+    Order order = new Order(100L, farRestaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+
+    Address courierAddr = new Address("2 Oak", null, "Oakland", "CA", "94612", 37.81, -122.28);
+    Courier courier = new Courier(new PersonName("Jane", "Doe"), courierAddr);
+    courier.updateLocation(37.81, -122.28);
+    when(courierRepository.findAllAvailable()).thenReturn(Collections.singletonList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+    when(meterRegistry.counter(anyString())).thenReturn(counter);
+
+    // readyBy very soon - pickup arrival will be after readyBy
+    LocalDateTime readyBy = LocalDateTime.now().plusMinutes(1);
+    orderService.scheduleDelivery(order, readyBy);
+
+    assertThat(order.getAssignedCourier()).isEqualTo(courier);
+  }
+
+  @Test
+  void shouldScheduleDeliveryWhenRestaurantAddressIsNull() {
+    Restaurant noAddrRestaurant = new Restaurant("No Addr", null,
+            new RestaurantMenu(Collections.singletonList(new MenuItem("1", "Chicken", new Money("10.00")))));
+    Order order = new Order(100L, noAddrRestaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+
+    Courier courier = new Courier(new PersonName("Jane", "Doe"),
+            new Address("2 Oak", null, "Oakland", "CA", "94612", 37.81, -122.28));
+    courier.updateLocation(37.81, -122.28);
+    when(courierRepository.findAllAvailable()).thenReturn(Collections.singletonList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+    when(meterRegistry.counter(anyString())).thenReturn(counter);
+
+    LocalDateTime readyBy = LocalDateTime.now().plusHours(1);
+    orderService.scheduleDelivery(order, readyBy);
+
+    assertThat(order.getAssignedCourier()).isEqualTo(courier);
+  }
+
+  @Test
+  void shouldScheduleDeliveryWithoutLocationData() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+
+    Courier courier = new Courier(new PersonName("Jane", "Doe"),
+            new Address("2 Oak", null, "Oakland", "CA", "94612"));
+    when(courierRepository.findAllAvailable()).thenReturn(Collections.singletonList(courier));
+    when(courierAssignmentStrategy.assignCourier(anyList(), any(Order.class))).thenReturn(courier);
+    when(meterRegistry.counter(anyString())).thenReturn(counter);
+
+    LocalDateTime readyBy = LocalDateTime.now().plusHours(1);
+    orderService.scheduleDelivery(order, readyBy);
+
+    assertThat(order.getAssignedCourier()).isEqualTo(courier);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/RevisedOrderTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/RevisedOrderTest.java
@@ -1,0 +1,31 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RevisedOrderTest {
+
+  @Test
+  void shouldCreateRevisedOrder() {
+    Restaurant restaurant = new Restaurant(1L, "Test",
+            new RestaurantMenu(Collections.emptyList()));
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+
+    Money currentTotal = new Money("20.00");
+    Money newTotal = new Money("30.00");
+    Money delta = new Money("10.00");
+    LineItemQuantityChange change = new LineItemQuantityChange(currentTotal, newTotal, delta);
+
+    RevisedOrder revisedOrder = new RevisedOrder(order, change);
+
+    assertThat(revisedOrder.getOrder()).isEqualTo(order);
+    assertThat(revisedOrder.getChange()).isEqualTo(change);
+    assertThat(revisedOrder.getChange().getDelta()).isEqualTo(new Money("10.00"));
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/GetOrderResponseTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/GetOrderResponseTest.java
@@ -1,0 +1,47 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.Action;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GetOrderResponseTest {
+
+  @Test
+  void shouldCreateGetOrderResponse() {
+    LocalDateTime deliveryTime = LocalDateTime.now().plusMinutes(30);
+    GetOrderResponse response = new GetOrderResponse(1L, "APPROVED", new Money("20.00"),
+            "Ajanta", 42L, Collections.emptyList(), deliveryTime);
+
+    assertThat(response.getOrderId()).isEqualTo(1L);
+    assertThat(response.getState()).isEqualTo("APPROVED");
+    assertThat(response.getOrderTotal()).isEqualTo(new Money("20.00"));
+    assertThat(response.getRestaurantName()).isEqualTo("Ajanta");
+    assertThat(response.getAssignedCourier()).isEqualTo(42L);
+    assertThat(response.getCourierActions()).isEmpty();
+    assertThat(response.getEstimatedDeliveryTime()).isEqualTo(deliveryTime);
+  }
+
+  @Test
+  void shouldSupportSetters() {
+    GetOrderResponse response = new GetOrderResponse(0L, null, null, null, null, null, null);
+    response.setOrderId(2L);
+    response.setState("DELIVERED");
+    response.setOrderTotal(new Money("30.00"));
+    response.setAssignedCourier(5L);
+    LocalDateTime time = LocalDateTime.now();
+    response.setEstimatedDeliveryTime(time);
+    response.setCourierActions(Collections.emptyList());
+
+    assertThat(response.getOrderId()).isEqualTo(2L);
+    assertThat(response.getState()).isEqualTo("DELIVERED");
+    assertThat(response.getOrderTotal()).isEqualTo(new Money("30.00"));
+    assertThat(response.getAssignedCourier()).isEqualTo(5L);
+    assertThat(response.getEstimatedDeliveryTime()).isEqualTo(time);
+    assertThat(response.getCourierActions()).isEmpty();
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/GetRestaurantResponseTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/GetRestaurantResponseTest.java
@@ -1,0 +1,21 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GetRestaurantResponseTest {
+
+  @Test
+  void shouldCreateGetRestaurantResponse() {
+    GetRestaurantResponse response = new GetRestaurantResponse(1L);
+    assertThat(response.getRestaurantId()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldSupportSetters() {
+    GetRestaurantResponse response = new GetRestaurantResponse(1L);
+    response.setRestaurantId(2L);
+    assertThat(response.getRestaurantId()).isEqualTo(2L);
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/MenuItemIdAndQuantityTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/MenuItemIdAndQuantityTest.java
@@ -1,0 +1,24 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MenuItemIdAndQuantityTest {
+
+  @Test
+  void shouldCreateMenuItemIdAndQuantity() {
+    MenuItemIdAndQuantity item = new MenuItemIdAndQuantity("item1", 3);
+
+    assertThat(item.getMenuItemId()).isEqualTo("item1");
+    assertThat(item.getQuantity()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldSupportSetters() {
+    MenuItemIdAndQuantity item = new MenuItemIdAndQuantity("item1", 1);
+    item.setMenuItemId("item2");
+
+    assertThat(item.getMenuItemId()).isEqualTo("item2");
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/OrderControllerUnitTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/OrderControllerUnitTest.java
@@ -1,0 +1,212 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.common.PersonName;
+import net.chrisrichardson.ftgo.domain.*;
+import net.chrisrichardson.ftgo.orderservice.api.web.CreateOrderRequest;
+import net.chrisrichardson.ftgo.orderservice.api.web.CreateOrderResponse;
+import net.chrisrichardson.ftgo.orderservice.api.web.ReviseOrderRequest;
+import net.chrisrichardson.ftgo.orderservice.api.web.OrderAcceptance;
+import net.chrisrichardson.ftgo.orderservice.domain.OrderNotFoundException;
+import net.chrisrichardson.ftgo.orderservice.domain.OrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderControllerUnitTest {
+
+  @Mock
+  private OrderService orderService;
+
+  @Mock
+  private OrderRepository orderRepository;
+
+  private OrderController controller;
+  private Restaurant restaurant;
+
+  @BeforeEach
+  void setUp() {
+    controller = new OrderController(orderService, orderRepository);
+    restaurant = new Restaurant(1L, "Ajanta",
+            new RestaurantMenu(Collections.singletonList(
+                    new MenuItem("1", "Chicken", new Money("10.00")))));
+    restaurant.setId(1L);
+  }
+
+  @Test
+  void shouldCreateOrder() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    when(orderService.createOrder(anyLong(), anyLong(), anyList())).thenReturn(order);
+
+    CreateOrderRequest request = new CreateOrderRequest(100L, 1L,
+            Collections.singletonList(new CreateOrderRequest.LineItem("1", 2)));
+
+    CreateOrderResponse response = controller.create(request);
+
+    assertThat(response.getOrderId()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldGetOrder() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    ResponseEntity<GetOrderResponse> response = controller.getOrder(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getOrderId()).isEqualTo(1L);
+    assertThat(response.getBody().getRestaurantName()).isEqualTo("Ajanta");
+  }
+
+  @Test
+  void shouldReturn404WhenOrderNotFound() {
+    when(orderRepository.findById(999L)).thenReturn(Optional.empty());
+
+    ResponseEntity<GetOrderResponse> response = controller.getOrder(999L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void shouldGetOrdersByConsumer() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    when(orderRepository.findAllByConsumerId(100L)).thenReturn(Collections.singletonList(order));
+
+    ResponseEntity<List<GetOrderResponse>> response = controller.getOrders(100L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).hasSize(1);
+  }
+
+  @Test
+  void shouldCancelOrder() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    when(orderService.cancel(1L)).thenReturn(order);
+
+    ResponseEntity<GetOrderResponse> response = controller.cancel(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void shouldReturn404WhenCancellingNonExistentOrder() {
+    when(orderService.cancel(999L)).thenThrow(new OrderNotFoundException(999L));
+
+    ResponseEntity<GetOrderResponse> response = controller.cancel(999L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReviseOrder() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 5)));
+    order.setId(1L);
+    when(orderService.reviseOrder(anyLong(), any(OrderRevision.class))).thenReturn(order);
+
+    Map<String, Integer> quantities = new HashMap<>();
+    quantities.put("1", 3);
+    ReviseOrderRequest request = new ReviseOrderRequest(quantities);
+
+    ResponseEntity<GetOrderResponse> response = controller.revise(1L, request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void shouldReturn404WhenRevisingNonExistentOrder() {
+    when(orderService.reviseOrder(anyLong(), any(OrderRevision.class))).thenThrow(new OrderNotFoundException(999L));
+
+    ReviseOrderRequest request = new ReviseOrderRequest(new HashMap<>());
+
+    ResponseEntity<GetOrderResponse> response = controller.revise(999L, request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void shouldAcceptOrder() {
+    LocalDateTime readyBy = LocalDateTime.now().plusHours(1);
+    OrderAcceptance acceptance = new OrderAcceptance(readyBy);
+
+    ResponseEntity<String> response = controller.accept(1L, acceptance);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).accept(1L, readyBy);
+  }
+
+  @Test
+  void shouldNotePreparing() {
+    ResponseEntity<String> response = controller.preparing(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).notePreparing(1L);
+  }
+
+  @Test
+  void shouldNoteReady() {
+    ResponseEntity<String> response = controller.ready(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).noteReadyForPickup(1L);
+  }
+
+  @Test
+  void shouldNotePickedUp() {
+    ResponseEntity<String> response = controller.pickedup(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).notePickedUp(1L);
+  }
+
+  @Test
+  void shouldNoteDelivered() {
+    ResponseEntity<String> response = controller.delivered(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(orderService).noteDelivered(1L);
+  }
+
+  @Test
+  void shouldGetOrderWithAssignedCourier() {
+    Order order = new Order(100L, restaurant, Collections.singletonList(
+            new OrderLineItem("1", "Chicken", new Money("10.00"), 2)));
+    order.setId(1L);
+    order.acceptTicket(LocalDateTime.now().plusHours(1));
+
+    Courier courier = new Courier(new PersonName("John", "Doe"),
+            new Address("1 Main", null, "Oakland", "CA", "94612", 37.8, -122.2));
+    courier.addAction(Action.makePickup(order));
+    courier.addAction(Action.makeDropoff(order, LocalDateTime.now().plusMinutes(30)));
+    order.schedule(courier);
+
+    when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+    ResponseEntity<GetOrderResponse> response = controller.getOrder(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getCourierActions()).isNotNull();
+    assertThat(response.getBody().getEstimatedDeliveryTime()).isNotNull();
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/TicketControllerTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/TicketControllerTest.java
@@ -1,0 +1,22 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import net.chrisrichardson.ftgo.orderservice.domain.OrderService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class TicketControllerTest {
+
+  @Mock
+  private OrderService orderService;
+
+  @Test
+  void shouldConstruct() {
+    TicketController controller = new TicketController(orderService);
+    assertThat(controller).isNotNull();
+  }
+}

--- a/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/domain/RestaurantServiceTest.java
+++ b/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/domain/RestaurantServiceTest.java
@@ -1,0 +1,67 @@
+package net.chrisrichardson.ftgo.restaurantservice.domain;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.Restaurant;
+import net.chrisrichardson.ftgo.domain.RestaurantRepository;
+import net.chrisrichardson.ftgo.restaurantservice.events.CreateRestaurantRequest;
+import net.chrisrichardson.ftgo.restaurantservice.events.MenuItemDTO;
+import net.chrisrichardson.ftgo.restaurantservice.events.RestaurantMenuDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantServiceTest {
+
+  @Mock
+  private RestaurantRepository restaurantRepository;
+
+  @InjectMocks
+  private RestaurantService restaurantService;
+
+  @Test
+  void shouldCreateRestaurant() {
+    Address address = new Address("1 Main St", null, "Oakland", "CA", "94612");
+    MenuItemDTO menuItem = new MenuItemDTO("1", "Chicken", new Money("10.00"));
+    RestaurantMenuDTO menu = new RestaurantMenuDTO(Collections.singletonList(menuItem));
+    CreateRestaurantRequest request = new CreateRestaurantRequest("Ajanta", address, menu);
+
+    Restaurant result = restaurantService.create(request);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getName()).isEqualTo("Ajanta");
+    verify(restaurantRepository).save(any(Restaurant.class));
+  }
+
+  @Test
+  void shouldFindRestaurantById() {
+    Restaurant restaurant = new Restaurant(1L, "Ajanta",
+            new net.chrisrichardson.ftgo.domain.RestaurantMenu(Collections.emptyList()));
+    when(restaurantRepository.findById(1L)).thenReturn(Optional.of(restaurant));
+
+    Optional<Restaurant> result = restaurantService.findById(1L);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getName()).isEqualTo("Ajanta");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenRestaurantNotFound() {
+    when(restaurantRepository.findById(999L)).thenReturn(Optional.empty());
+
+    Optional<Restaurant> result = restaurantService.findById(999L);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/web/RestaurantControllerTest.java
+++ b/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/web/RestaurantControllerTest.java
@@ -1,0 +1,75 @@
+package net.chrisrichardson.ftgo.restaurantservice.web;
+
+import net.chrisrichardson.ftgo.common.Address;
+import net.chrisrichardson.ftgo.common.Money;
+import net.chrisrichardson.ftgo.domain.Restaurant;
+import net.chrisrichardson.ftgo.domain.RestaurantMenu;
+import net.chrisrichardson.ftgo.restaurantservice.domain.RestaurantService;
+import net.chrisrichardson.ftgo.restaurantservice.events.CreateRestaurantRequest;
+import net.chrisrichardson.ftgo.restaurantservice.events.MenuItemDTO;
+import net.chrisrichardson.ftgo.restaurantservice.events.RestaurantMenuDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantControllerTest {
+
+  @Mock
+  private RestaurantService restaurantService;
+
+  @Mock
+  private Restaurant mockRestaurant;
+
+  @InjectMocks
+  private RestaurantController controller;
+
+  @Test
+  void shouldCreateRestaurant() {
+    when(mockRestaurant.getId()).thenReturn(1L);
+    when(restaurantService.create(any(CreateRestaurantRequest.class))).thenReturn(mockRestaurant);
+
+    Address address = new Address("1 Main St", null, "Oakland", "CA", "94612");
+    MenuItemDTO menuItem = new MenuItemDTO("1", "Chicken", new Money("10.00"));
+    RestaurantMenuDTO menu = new RestaurantMenuDTO(Collections.singletonList(menuItem));
+    CreateRestaurantRequest request = new CreateRestaurantRequest("Ajanta", address, menu);
+
+    CreateRestaurantResponse response = controller.create(request);
+
+    assertThat(response.getId()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldGetRestaurant() {
+    when(mockRestaurant.getId()).thenReturn(1L);
+    when(mockRestaurant.getName()).thenReturn("Ajanta");
+    when(restaurantService.findById(1L)).thenReturn(Optional.of(mockRestaurant));
+
+    ResponseEntity<GetRestaurantResponse> response = controller.get(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getName()).isEqualTo("Ajanta");
+    assertThat(response.getBody().getId()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldReturn404WhenRestaurantNotFound() {
+    when(restaurantService.findById(999L)).thenReturn(Optional.empty());
+
+    ResponseEntity<GetRestaurantResponse> response = controller.get(999L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+}

--- a/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/web/RestaurantResponseTest.java
+++ b/ftgo-restaurant-service/src/test/java/net/chrisrichardson/ftgo/restaurantservice/web/RestaurantResponseTest.java
@@ -1,0 +1,41 @@
+package net.chrisrichardson.ftgo.restaurantservice.web;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestaurantResponseTest {
+
+  @Test
+  void shouldCreateGetRestaurantResponse() {
+    GetRestaurantResponse response = new GetRestaurantResponse(1L, "Ajanta");
+
+    assertThat(response.getId()).isEqualTo(1L);
+    assertThat(response.getName()).isEqualTo("Ajanta");
+  }
+
+  @Test
+  void shouldSupportGetRestaurantResponseSetters() {
+    GetRestaurantResponse response = new GetRestaurantResponse();
+    response.setId(2L);
+    response.setName("Updated");
+
+    assertThat(response.getId()).isEqualTo(2L);
+    assertThat(response.getName()).isEqualTo("Updated");
+  }
+
+  @Test
+  void shouldCreateCreateRestaurantResponse() {
+    CreateRestaurantResponse response = new CreateRestaurantResponse(1L);
+
+    assertThat(response.getId()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldSupportCreateRestaurantResponseSetters() {
+    CreateRestaurantResponse response = new CreateRestaurantResponse();
+    response.setId(3L);
+
+    assertThat(response.getId()).isEqualTo(3L);
+  }
+}


### PR DESCRIPTION
## Summary

Adds **50+ unit test classes** across 6 modules with JaCoCo coverage enforcement, achieving **95.7% line** and **88.7% branch** coverage overall.

### Build configuration (`build.gradle`)
- JUnit 5.9.3 + Mockito 4.11.0 + AssertJ 3.24.2 added to all subprojects
- JaCoCo 0.8.10 with `jacocoTestCoverageVerification` enforcing ≥95% line / ≥85% branch per module
- `--add-opens` JVM args for Java 17 compatibility with Mockito/ByteBuddy
- Spring `@Configuration` classes excluded from coverage verification (require Spring context, not unit-testable)

### Test coverage by module

| Module | LINE | BRANCH |
|--------|------|--------|
| ftgo-common | 95.1% | 92.9% |
| ftgo-domain | 97.7% | 85.5% |
| ftgo-order-service | 96.1% | 88.9% |
| ftgo-consumer-service | 81.8%* | — |
| ftgo-courier-service | 93.2%* | 100% |
| ftgo-restaurant-service | 91.7%* | — |
| **Overall** | **95.7%** | **88.7%** |

*Consumer/courier/restaurant service raw numbers include `@Configuration` classes excluded from verification.

### Key test areas
- **Order lifecycle**: Full state machine (`APPROVED→ACCEPTED→PREPARING→READY_FOR_PICKUP→PICKED_UP→DELIVERED`), cancellation, revision with delivery info, invalid transitions
- **Courier assignment**: `DistanceOptimizedCourierAssignmentStrategy` — distance scoring, load balancing, max-capacity fallback, no-location fallback
- **Service layer**: `OrderService`, `ConsumerService`, `CourierService`, `RestaurantService` with mocked repositories
- **Web layer**: All controllers tested with Mockito mocks — happy paths, 404s, error handling
- **Value objects/DTOs**: `Money`, `Address`, `PersonName`, `OrderRevision`, response DTOs

Link to Devin session: https://app.devin.ai/sessions/c15e03b09e9645eeaa89e01b03bcd39d
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/245?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->