### PR TITLE
Fix: Deeply nested json in jackson-databind

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,19 @@ subprojects {
 
     group = "net.chrisrichardson.ftgo"
 
+    ext['jackson.version'] = '2.13.5'
+
+    configurations.all {
+        resolutionStrategy {
+            force "com.fasterxml.jackson.core:jackson-core:2.13.5",
+                  "com.fasterxml.jackson.core:jackson-annotations:2.13.5",
+                  "com.fasterxml.jackson.core:jackson-databind:2.13.5",
+                  "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5",
+                  "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5",
+                  "com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5"
+        }
+    }
+
     repositories {
         mavenCentral()
         jcenter()

--- a/ftgo-common/build.gradle
+++ b/ftgo-common/build.gradle
@@ -5,10 +5,10 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.7'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.7'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.5'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.5'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.7"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5"
 
     compile 'mysql:mysql-connector-java:8.0.33'
 


### PR DESCRIPTION
## Summary
Finding: **Deeply nested json in jackson-databind** (CVE-2020-36518 / [GHSA-57j2-w4cx-62h2](https://github.com/advisories/GHSA-57j2-w4cx-62h2), HIGH 7.5) in repo **COG-GTM/ftgo-monolith**.

Fix approach: upgrade Jackson from 2.9.x to 2.13.5 across the build — `ftgo-common/build.gradle` pins (`jackson-core`, `jackson-databind`, `jackson-datatype-jsr310`) plus a root-level `ext['jackson.version']` and `resolutionStrategy.force` in `build.gradle` so the Spring Boot 2.0.3 dependency-management BOM (which otherwise pins Jackson back to 2.9.6) cannot downgrade it in modules applying `FtgoServicePlugin`.

The app deserializes untrusted JSON in every `@RequestBody` controller endpoint (OrderController, ConsumerController, RestaurantController, CourierController); jackson-databind < 2.12.6.1 throws an uncaught `StackOverflowError` on deeply nested JSON, enabling remote DoS. Verified after the change that `:ftgo-application` resolves all Jackson artifacts to 2.13.5 and that compilation and existing unit tests (`:ftgo-common:test`, `:ftgo-domain:test`) pass (the `OrderControllerTest` failures and `ftgo-end-to-end-tests-common` resolution failure are preexisting on master).

Link to Devin session: https://app.devin.ai/sessions/b02f17b96453416cafe2b410e9763e87
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/267?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->