### PR TITLE
Fix: Missing authentication on /api/tracking request-log endpoints

### DIFF
--- a/ftgo-application/src/main/resources/application.properties
+++ b/ftgo-application/src/main/resources/application.properties
@@ -9,5 +9,6 @@ spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # /api/tracking/** is disabled unless an admin token is configured; callers must
-# then send it in the X-Api-Tracking-Token header.
+# then send it in the X-Api-Tracking-Token header. Tokens shorter than 32
+# characters are ignored and leave the endpoints disabled.
 # ftgo.api-tracking.admin-token=${FTGO_API_TRACKING_ADMIN_TOKEN:}

--- a/ftgo-application/src/main/resources/application.properties
+++ b/ftgo-application/src/main/resources/application.properties
@@ -7,3 +7,7 @@ spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo?useSSL=false
 spring.datasource.username=mysqluser
 spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# /api/tracking/** is disabled unless an admin token is configured; callers must
+# then send it in the X-Api-Tracking-Token header.
+# ftgo.api-tracking.admin-token=${FTGO_API_TRACKING_ADMIN_TOKEN:}

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptor.java
@@ -1,0 +1,43 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ApiTrackingAuthInterceptor implements HandlerInterceptor {
+
+  static final String ADMIN_TOKEN_HEADER = "X-Api-Tracking-Token";
+
+  private final String configuredToken;
+
+  public ApiTrackingAuthInterceptor(String configuredToken) {
+    this.configuredToken = configuredToken;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (configuredToken == null || configuredToken.isEmpty()) {
+      response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+      return false;
+    }
+
+    String presentedToken = request.getHeader(ADMIN_TOKEN_HEADER);
+    if (presentedToken == null || !constantTimeEquals(configuredToken, presentedToken)) {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return false;
+    }
+
+    return true;
+  }
+
+  private static boolean constantTimeEquals(String expected, String presented) {
+    byte[] expectedBytes = expected.getBytes();
+    byte[] presentedBytes = presented.getBytes();
+    int result = expectedBytes.length ^ presentedBytes.length;
+    for (int i = 0; i < presentedBytes.length; i++) {
+      result |= presentedBytes[i] ^ expectedBytes[i % expectedBytes.length];
+    }
+    return result == 0;
+  }
+}

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptor.java
@@ -1,5 +1,7 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -11,16 +13,25 @@ import java.security.NoSuchAlgorithmException;
 public class ApiTrackingAuthInterceptor implements HandlerInterceptor {
 
   static final String ADMIN_TOKEN_HEADER = "X-Api-Tracking-Token";
+  static final int MINIMUM_TOKEN_LENGTH = 32;
+
+  private static final Logger logger = LoggerFactory.getLogger(ApiTrackingAuthInterceptor.class);
 
   private final String configuredToken;
 
   public ApiTrackingAuthInterceptor(String configuredToken) {
-    this.configuredToken = configuredToken;
+    String trimmed = configuredToken == null ? "" : configuredToken.trim();
+    if (!trimmed.isEmpty() && trimmed.length() < MINIMUM_TOKEN_LENGTH) {
+      logger.warn("Ignoring ftgo.api-tracking.admin-token shorter than {} characters; /api/tracking/** stays disabled",
+              MINIMUM_TOKEN_LENGTH);
+      trimmed = "";
+    }
+    this.configuredToken = trimmed;
   }
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-    if (configuredToken == null || configuredToken.isEmpty()) {
+    if (configuredToken.isEmpty()) {
       response.setStatus(HttpServletResponse.SC_NOT_FOUND);
       return false;
     }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptor.java
@@ -4,6 +4,9 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 public class ApiTrackingAuthInterceptor implements HandlerInterceptor {
 
@@ -32,12 +35,14 @@ public class ApiTrackingAuthInterceptor implements HandlerInterceptor {
   }
 
   private static boolean constantTimeEquals(String expected, String presented) {
-    byte[] expectedBytes = expected.getBytes();
-    byte[] presentedBytes = presented.getBytes();
-    int result = expectedBytes.length ^ presentedBytes.length;
-    for (int i = 0; i < presentedBytes.length; i++) {
-      result |= presentedBytes[i] ^ expectedBytes[i % expectedBytes.length];
+    return MessageDigest.isEqual(sha256(expected), sha256(presented));
+  }
+
+  private static byte[] sha256(String value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is required to compare API tracking tokens", e);
     }
-    return result == 0;
   }
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptor.java
@@ -22,8 +22,8 @@ public class ApiTrackingAuthInterceptor implements HandlerInterceptor {
   public ApiTrackingAuthInterceptor(String configuredToken) {
     String trimmed = configuredToken == null ? "" : configuredToken.trim();
     if (!trimmed.isEmpty() && trimmed.length() < MINIMUM_TOKEN_LENGTH) {
-      logger.warn("Ignoring ftgo.api-tracking.admin-token shorter than {} characters; /api/tracking/** stays disabled",
-              MINIMUM_TOKEN_LENGTH);
+      logger.error("ftgo.api-tracking.admin-token is shorter than {} characters and was ignored; "
+              + "/api/tracking/** stays disabled and returns 404", MINIMUM_TOKEN_LENGTH);
       trimmed = "";
     }
     this.configuredToken = trimmed;
@@ -37,7 +37,7 @@ public class ApiTrackingAuthInterceptor implements HandlerInterceptor {
     }
 
     String presentedToken = request.getHeader(ADMIN_TOKEN_HEADER);
-    if (presentedToken == null || !constantTimeEquals(configuredToken, presentedToken)) {
+    if (presentedToken == null || !constantTimeEquals(configuredToken, presentedToken.trim())) {
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
       return false;
     }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -9,9 +10,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class ApiTrackingConfiguration implements WebMvcConfigurer {
 
   private final ApiRequestLogRepository apiRequestLogRepository;
+  private final String adminToken;
 
-  public ApiTrackingConfiguration(ApiRequestLogRepository apiRequestLogRepository) {
+  public ApiTrackingConfiguration(ApiRequestLogRepository apiRequestLogRepository,
+                                  @Value("${ftgo.api-tracking.admin-token:}") String adminToken) {
     this.apiRequestLogRepository = apiRequestLogRepository;
+    this.adminToken = adminToken;
   }
 
   @Override
@@ -19,10 +23,18 @@ public class ApiTrackingConfiguration implements WebMvcConfigurer {
     registry.addInterceptor(apiTrackingInterceptor())
             .addPathPatterns("/**")
             .excludePathPatterns("/api/tracking/**", "/actuator/**");
+
+    registry.addInterceptor(apiTrackingAuthInterceptor())
+            .addPathPatterns("/api/tracking/**");
   }
 
   @Bean
   public ApiTrackingInterceptor apiTrackingInterceptor() {
     return new ApiTrackingInterceptor(apiRequestLogRepository);
+  }
+
+  @Bean
+  public ApiTrackingAuthInterceptor apiTrackingAuthInterceptor() {
+    return new ApiTrackingAuthInterceptor(adminToken);
   }
 }

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptorTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptorTest.java
@@ -1,0 +1,61 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ApiTrackingAuthInterceptorTest {
+
+  private static final String TOKEN = "0123456789abcdef0123456789abcdef";
+
+  private final MockHttpServletResponse response = new MockHttpServletResponse();
+
+  @Test
+  public void shouldHideEndpointsWhenNoTokenIsConfigured() {
+    assertFalse(preHandle(null, TOKEN));
+    assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  public void shouldIgnoreTokenShorterThanMinimumLength() {
+    assertFalse(preHandle("tooshort", "tooshort"));
+    assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  public void shouldRejectMissingToken() {
+    assertFalse(preHandle(TOKEN, null));
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+  }
+
+  @Test
+  public void shouldRejectWrongToken() {
+    assertFalse(preHandle(TOKEN, TOKEN.replace('0', '1')));
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+  }
+
+  @Test
+  public void shouldAcceptConfiguredToken() {
+    assertTrue(preHandle(TOKEN, TOKEN));
+    assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+  }
+
+  @Test
+  public void shouldAcceptConfiguredTokenSurroundedByWhitespace() {
+    assertTrue(preHandle(" " + TOKEN + " ", "\t" + TOKEN + "\n"));
+  }
+
+  private boolean preHandle(String configuredToken, String presentedToken) {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/tracking/logs");
+    if (presentedToken != null) {
+      request.addHeader(ApiTrackingAuthInterceptor.ADMIN_TOKEN_HEADER, presentedToken);
+    }
+    return new ApiTrackingAuthInterceptor(configuredToken).preHandle(request, response, new Object());
+  }
+}

--- a/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptorTest.java
+++ b/ftgo-common/src/test/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingAuthInterceptorTest.java
@@ -49,6 +49,7 @@ public class ApiTrackingAuthInterceptorTest {
   @Test
   public void shouldAcceptConfiguredTokenSurroundedByWhitespace() {
     assertTrue(preHandle(" " + TOKEN + " ", "\t" + TOKEN + "\n"));
+    assertEquals(HttpServletResponse.SC_OK, response.getStatus());
   }
 
   private boolean preHandle(String configuredToken, String presentedToken) {


### PR DESCRIPTION
## Summary

Finding: **Missing authentication on /api/tracking request-log endpoints** in `COG-GTM/ftgo-monolith`.

`ApiTrackingController` served `/api/tracking/logs`, `/logs/errors`, `/logs/search`, `/logs/{correlationId}` and `/stats` to any caller — the repo has no `spring-boot-starter-security` anywhere — exposing recorded client IPs, request URIs, query strings, user agents and internal exception messages for all traffic.

Fix approach: gate `/api/tracking/**` behind a new `ApiTrackingAuthInterceptor` that requires a shared admin token, so the endpoints are closed by default.

```
registry.addInterceptor(apiTrackingAuthInterceptor()).addPathPatterns("/api/tracking/**")

preHandle:
  ftgo.api-tracking.admin-token unset / < 32 chars -> 404 (feature effectively disabled)
  X-Api-Tracking-Token != token                    -> 401
  otherwise                                        -> allow
```

Both sides are hashed to fixed-length SHA-256 digests before `MessageDigest.isEqual`, so neither token content nor length leaks via timing. Configured and presented values are trimmed; a non-empty token below `MINIMUM_TOKEN_LENGTH` (32) is discarded with an ERROR log rather than enabling the endpoints behind a guessable secret — the fallback state is the closed one, so this deliberately does not fail startup (`ftgo-common` is a compile dependency of every service).

No existing control was weakened; the request-recording interceptor is unchanged.

Note: `./gradlew compileJava` could not be run in this environment — Maven Central returned HTTP 429 for `buildSrc` dependencies (and the wrapper is Gradle 4.10.2, which predates the available JDKs), so the change is unverified by a local build.

Link to Devin session: https://app.devin.ai/sessions/574b031ec6984da9b788d44f5257aeff
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/268?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->