### PR TITLE
Fix: Client IP addresses and raw request query strings persisted indefinitely in api_request_log

### DIFF
--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
@@ -1,8 +1,10 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,5 +22,10 @@ public interface ApiRequestLogRepository extends CrudRepository<ApiRequestLog, L
 
   @Query("SELECT a FROM ApiRequestLog a WHERE a.responseStatus >= 400 AND a.requestTimestamp >= :since ORDER BY a.requestTimestamp DESC")
   List<ApiRequestLog> findErrorsSince(@Param("since") LocalDateTime since);
+
+  @Modifying
+  @Transactional
+  @Query("DELETE FROM ApiRequestLog a WHERE a.requestTimestamp < :cutoff")
+  int deleteByRequestTimestampBefore(@Param("cutoff") LocalDateTime cutoff);
 
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionJob.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionJob.java
@@ -1,0 +1,30 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
+
+public class ApiRequestLogRetentionJob {
+
+  private static final Logger logger = LoggerFactory.getLogger(ApiRequestLogRetentionJob.class);
+
+  private final ApiRequestLogRepository apiRequestLogRepository;
+  private final int retentionDays;
+
+  public ApiRequestLogRetentionJob(ApiRequestLogRepository apiRequestLogRepository, int retentionDays) {
+    this.apiRequestLogRepository = apiRequestLogRepository;
+    this.retentionDays = retentionDays;
+  }
+
+  @Scheduled(fixedDelayString = "${ftgo.api-tracking.purge-interval-ms:3600000}")
+  public void purgeExpiredLogs() {
+    LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
+    try {
+      apiRequestLogRepository.deleteByRequestTimestampBefore(cutoff);
+    } catch (Exception e) {
+      logger.warn("Failed to purge API request logs older than {}: {}", cutoff, e.getMessage());
+    }
+  }
+}

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionJob.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionJob.java
@@ -14,6 +14,9 @@ public class ApiRequestLogRetentionJob {
   private final int retentionDays;
 
   public ApiRequestLogRetentionJob(ApiRequestLogRepository apiRequestLogRepository, int retentionDays) {
+    if (retentionDays < 1) {
+      throw new IllegalArgumentException("ftgo.api-tracking.retention-days must be at least 1, was " + retentionDays);
+    }
     this.apiRequestLogRepository = apiRequestLogRepository;
     this.retentionDays = retentionDays;
   }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionJob.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionJob.java
@@ -22,9 +22,10 @@ public class ApiRequestLogRetentionJob {
   public void purgeExpiredLogs() {
     LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
     try {
-      apiRequestLogRepository.deleteByRequestTimestampBefore(cutoff);
+      int deleted = apiRequestLogRepository.deleteByRequestTimestampBefore(cutoff);
+      logger.info("Purged {} API request log rows older than {}", deleted, cutoff);
     } catch (Exception e) {
-      logger.warn("Failed to purge API request logs older than {}: {}", cutoff, e.getMessage());
+      logger.warn("Failed to purge API request logs older than {}", cutoff, e);
     }
   }
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
@@ -1,17 +1,23 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableScheduling
 public class ApiTrackingConfiguration implements WebMvcConfigurer {
 
   private final ApiRequestLogRepository apiRequestLogRepository;
+  private final int retentionDays;
 
-  public ApiTrackingConfiguration(ApiRequestLogRepository apiRequestLogRepository) {
+  public ApiTrackingConfiguration(ApiRequestLogRepository apiRequestLogRepository,
+                                  @Value("${ftgo.api-tracking.retention-days:30}") int retentionDays) {
     this.apiRequestLogRepository = apiRequestLogRepository;
+    this.retentionDays = retentionDays;
   }
 
   @Override
@@ -24,5 +30,10 @@ public class ApiTrackingConfiguration implements WebMvcConfigurer {
   @Bean
   public ApiTrackingInterceptor apiTrackingInterceptor() {
     return new ApiTrackingInterceptor(apiRequestLogRepository);
+  }
+
+  @Bean
+  public ApiRequestLogRetentionJob apiRequestLogRetentionJob() {
+    return new ApiRequestLogRetentionJob(apiRequestLogRepository, retentionDays);
   }
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -117,7 +117,10 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
               ? remoteAddr.substring(0, lastColon)
               : remoteAddr;
       int prefixEnd = host.lastIndexOf(':');
-      return host.substring(0, prefixEnd + 1) + anonymizeIpv4(host.substring(prefixEnd + 1));
+      String ipv4 = host.substring(prefixEnd + 1);
+      return isIpv4Literal(ipv4)
+              ? host.substring(0, prefixEnd + 1) + anonymizeIpv4(ipv4)
+              : REDACTED;
     }
     if (remoteAddr.indexOf(':') < 0) {
       return remoteAddr;
@@ -132,6 +135,27 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
       retained++;
     }
     return retained == 0 ? "::" : prefix.append(':').toString();
+  }
+
+  private static boolean isIpv4Literal(String address) {
+    String[] octets = address.split("\\.", -1);
+    if (octets.length != 4) {
+      return false;
+    }
+    for (String octet : octets) {
+      if (octet.isEmpty() || octet.length() > 3) {
+        return false;
+      }
+      for (int i = 0; i < octet.length(); i++) {
+        if (octet.charAt(i) < '0' || octet.charAt(i) > '9') {
+          return false;
+        }
+      }
+      if (Integer.parseInt(octet) > 255) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private static String anonymizeIpv4(String address) {

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -111,12 +111,16 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     if (remoteAddr == null || remoteAddr.isEmpty()) {
       return remoteAddr;
     }
-    if (remoteAddr.indexOf(':') < 0) {
-      return anonymizeIpv4(remoteAddr);
+    if (remoteAddr.indexOf('.') >= 0) {
+      int lastColon = remoteAddr.lastIndexOf(':');
+      String host = lastColon >= 0 && remoteAddr.indexOf('.', lastColon) < 0
+              ? remoteAddr.substring(0, lastColon)
+              : remoteAddr;
+      int prefixEnd = host.lastIndexOf(':');
+      return host.substring(0, prefixEnd + 1) + anonymizeIpv4(host.substring(prefixEnd + 1));
     }
-    int lastColon = remoteAddr.lastIndexOf(':');
-    if (remoteAddr.indexOf('.', lastColon) > 0) {
-      return remoteAddr.substring(0, lastColon + 1) + anonymizeIpv4(remoteAddr.substring(lastColon + 1));
+    if (remoteAddr.indexOf(':') < 0) {
+      return remoteAddr;
     }
     StringBuilder prefix = new StringBuilder();
     int retained = 0;

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -117,9 +117,10 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
               ? remoteAddr.substring(0, lastColon)
               : remoteAddr;
       int prefixEnd = host.lastIndexOf(':');
+      String prefix = host.substring(0, prefixEnd + 1);
       String ipv4 = host.substring(prefixEnd + 1);
-      return isIpv4Literal(ipv4)
-              ? host.substring(0, prefixEnd + 1) + anonymizeIpv4(ipv4)
+      return isIpv4Literal(ipv4) && isIpv4MappedPrefix(prefix)
+              ? prefix + anonymizeIpv4(ipv4)
               : REDACTED;
     }
     if (remoteAddr.indexOf(':') < 0) {
@@ -135,6 +136,10 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
       retained++;
     }
     return retained == 0 ? "::" : prefix.append(':').toString();
+  }
+
+  private static boolean isIpv4MappedPrefix(String prefix) {
+    return prefix.isEmpty() || prefix.equals("::") || prefix.equalsIgnoreCase("::ffff:");
   }
 
   private static boolean isIpv4Literal(String address) {

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -40,8 +40,8 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
             correlationId,
             request.getMethod(),
             request.getRequestURI(),
-            request.getQueryString(),
-            request.getRemoteAddr(),
+            redactQueryStringValues(request.getQueryString()),
+            anonymizeIp(request.getRemoteAddr()),
             request.getHeader("User-Agent")
     );
 
@@ -83,5 +83,36 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     }
 
     MDC.remove("correlationId");
+  }
+
+  static String redactQueryStringValues(String queryString) {
+    if (queryString == null || queryString.isEmpty()) {
+      return queryString;
+    }
+    StringBuilder redacted = new StringBuilder(queryString.length());
+    for (String pair : queryString.split("&")) {
+      if (redacted.length() > 0) {
+        redacted.append('&');
+      }
+      int separator = pair.indexOf('=');
+      redacted.append(separator < 0 ? pair : pair.substring(0, separator) + "=REDACTED");
+    }
+    return redacted.toString();
+  }
+
+  static String anonymizeIp(String remoteAddr) {
+    if (remoteAddr == null || remoteAddr.isEmpty()) {
+      return remoteAddr;
+    }
+    if (remoteAddr.indexOf(':') >= 0) {
+      String[] groups = remoteAddr.split(":");
+      StringBuilder prefix = new StringBuilder();
+      for (int i = 0; i < Math.min(4, groups.length); i++) {
+        prefix.append(groups[i]).append(':');
+      }
+      return prefix.append(':').toString();
+    }
+    int lastDot = remoteAddr.lastIndexOf('.');
+    return lastDot < 0 ? remoteAddr : remoteAddr.substring(0, lastDot) + ".0";
   }
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -93,6 +93,9 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     }
     StringBuilder redacted = new StringBuilder(queryString.length());
     for (String pair : queryString.split("&")) {
+      if (pair.isEmpty()) {
+        continue;
+      }
       if (redacted.length() > 0) {
         redacted.append('&');
       }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -16,6 +16,8 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
   private static final String CORRELATION_ID_HEADER = "X-Correlation-ID";
   private static final String START_TIME_ATTR = "apiTracking.startTime";
   private static final String LOG_ENTRY_ATTR = "apiTracking.logEntry";
+  private static final String REDACTED = "REDACTED";
+  private static final int MAX_QUERY_STRING_LENGTH = 2048;
 
   private final ApiRequestLogRepository apiRequestLogRepository;
 
@@ -95,24 +97,38 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
         redacted.append('&');
       }
       int separator = pair.indexOf('=');
-      redacted.append(separator < 0 ? pair : pair.substring(0, separator) + "=REDACTED");
+      redacted.append(separator < 0 ? REDACTED : pair.substring(0, separator + 1) + REDACTED);
     }
-    return redacted.toString();
+    return redacted.length() > MAX_QUERY_STRING_LENGTH
+            ? redacted.substring(0, MAX_QUERY_STRING_LENGTH)
+            : redacted.toString();
   }
 
   static String anonymizeIp(String remoteAddr) {
     if (remoteAddr == null || remoteAddr.isEmpty()) {
       return remoteAddr;
     }
-    if (remoteAddr.indexOf(':') >= 0) {
-      String[] groups = remoteAddr.split(":");
-      StringBuilder prefix = new StringBuilder();
-      for (int i = 0; i < Math.min(4, groups.length); i++) {
-        prefix.append(groups[i]).append(':');
-      }
-      return prefix.append(':').toString();
+    if (remoteAddr.indexOf(':') < 0) {
+      return anonymizeIpv4(remoteAddr);
     }
-    int lastDot = remoteAddr.lastIndexOf('.');
-    return lastDot < 0 ? remoteAddr : remoteAddr.substring(0, lastDot) + ".0";
+    int lastColon = remoteAddr.lastIndexOf(':');
+    if (remoteAddr.indexOf('.', lastColon) > 0) {
+      return remoteAddr.substring(0, lastColon + 1) + anonymizeIpv4(remoteAddr.substring(lastColon + 1));
+    }
+    StringBuilder prefix = new StringBuilder();
+    int retained = 0;
+    for (String group : remoteAddr.split(":", -1)) {
+      if (group.isEmpty() || retained == 3) {
+        break;
+      }
+      prefix.append(group).append(':');
+      retained++;
+    }
+    return retained == 0 ? "::" : prefix.append(':').toString();
+  }
+
+  private static String anonymizeIpv4(String address) {
+    int lastDot = address.lastIndexOf('.');
+    return lastDot < 0 ? address : address.substring(0, lastDot) + ".0";
   }
 }


### PR DESCRIPTION
## Summary

Finding: **Client IP addresses and raw request query strings persisted indefinitely in api_request_log** in `COG-GTM/ftgo-monolith` (NS terms / data-minimization gap, not an exploitable bug).

`ApiTrackingInterceptor` wrote `getRemoteAddr()`, the full query string and the User-Agent of every request into the `api_request_log` table that lives in the same `ftgo` schema as consumer names, delivery addresses and payment tokens, and nothing in the repo ever deleted those rows.

Fix approach: minimize what is stored and give the table a bounded lifecycle.

```
remoteAddr   "203.0.113.47"          -> "203.0.113.0"             (/24)
             "2001:db8:85a3:1:2:3:4:5" -> "2001:db8:85a3::"       (/48)
             "::ffff:203.0.113.47"   -> "::ffff:203.0.113.0"      (IPv4-mapped)
queryString  "uri=/consumers&x=Jo"   -> "uri=REDACTED&x=REDACTED"
             "?john@example.com"     -> "REDACTED"                (keyless token)

ApiRequestLogRetentionJob @Scheduled(ftgo.api-tracking.purge-interval-ms, default 1h)
  -> deleteByRequestTimestampBefore(now - ftgo.api-tracking.retention-days, default 30)
```

Parameter *names* are kept so the endpoint-level diagnostics the tracking feature exists for still work; only values are dropped. Because `=REDACTED` can make the string grow, the result is truncated to `MAX_QUERY_STRING_LENGTH` (2048), matching the `query_string VARCHAR(2048)` column — so an over-long request now loses trailing parameter names rather than failing to persist.

User-Agent is deliberately retained: it is client-declared, low-cardinality, cannot carry account identifiers, and is the field with real diagnostic value; its fingerprinting risk came from pairing it with a full client IP, which this change removes.

`retentionDays < 1` is rejected in the job constructor, so a misconfigured `retention-days=0` fails startup instead of silently deleting the whole table every hour.

Note: `./gradlew compileJava` could not be run in this environment — Maven Central returned HTTP 429 for `buildSrc` dependencies (and the wrapper is Gradle 4.10.2, which predates the available JDKs), so the change is unverified by a local build. The `redactQueryStringValues` and `anonymizeIp` helpers were extracted and exercised standalone under JDK 17 to confirm the outputs above.

Link to Devin session: https://app.devin.ai/sessions/574b031ec6984da9b788d44f5257aeff
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/269?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->