### PR TITLE
Fix: Cross-site scripting in Swagger-UI

### DIFF
--- a/common-swagger/build.gradle
+++ b/common-swagger/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile ("io.springfox:springfox-swagger2:2.8.0") {
+    compile ("io.springfox:springfox-swagger2:2.10.5") {
         exclude group: "org.springframework"
     }
-    compile ("io.springfox:springfox-swagger-ui:2.8.0"){
+    compile ("io.springfox:springfox-swagger-ui:2.10.5"){
         exclude group: "org.springframework"
     }
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"

--- a/common-swagger/build.gradle
+++ b/common-swagger/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     compile ("io.springfox:springfox-swagger-ui:2.10.5"){
         exclude group: "org.springframework"
     }
+    // springfox 2.10.x pulls classgraph 4.8.83, which is vulnerable to CVE-2021-47621 (XXE)
+    compile "io.github.classgraph:classgraph:4.8.112"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
 }

--- a/common-swagger/build.gradle
+++ b/common-swagger/build.gradle
@@ -1,12 +1,10 @@
 dependencies {
-    compile ("io.springfox:springfox-swagger2:2.10.5") {
+    compile ("io.springfox:springfox-swagger2:2.8.0") {
         exclude group: "org.springframework"
     }
     compile ("io.springfox:springfox-swagger-ui:2.10.5"){
         exclude group: "org.springframework"
     }
-    // springfox 2.10.x pulls classgraph 4.8.83, which is vulnerable to CVE-2021-47621 (XXE)
-    compile "io.github.classgraph:classgraph:4.8.112"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
 }


### PR DESCRIPTION
## Summary

Finding: **Cross-site scripting in Swagger-UI** (CVE-2019-17495, [GHSA-c427-hjc3-wrfw](https://github.com/advisories/GHSA-c427-hjc3-wrfw)) in `COG-GTM/ftgo-monolith`.

`common-swagger/build.gradle` pinned `io.springfox:springfox-swagger-ui:2.8.0`, which bundles a Swagger UI older than 3.23.11 and is inside the advisory's affected range (`< 2.10.0`). The UI is reachable unauthenticated at `/swagger-ui.html` because `common-swagger` (with `@EnableSwagger2`) is a compile dependency of every service module in `ftgo-application`, so untrusted JSON rendered by the UI can carry `@import` and exfiltrate input field values via Relative Path Overwrite.

Fix approach: upgrade the vulnerable artifact `springfox-swagger-ui` to the patched 2.10.5 and deliberately leave `springfox-swagger2` where it is.

```
io.springfox:springfox-swagger-ui:2.8.0  -> 2.10.5   (vulnerable artifact, patched)
io.springfox:springfox-swagger2:2.8.0    -> unchanged
```

Why the split rather than upgrading both (the non-obvious part):

- The advisory is against `springfox-swagger-ui`, which is the artifact shipping the Swagger UI JS bundle.
- `springfox-swagger-ui:2.10.5` declares exactly one dependency, `springfox-spring-webmvc`, at `provided` scope — so this brings in **no** new transitive dependencies and the rest of the graph is unchanged.
- Upgrading `springfox-swagger2` to 2.10.x instead drags in the restructured springfox stack (`springfox-core`, `springfox-spring-web`, `spring-plugin` 2.0.0, `mapstruct`, and `classgraph` 4.8.83 — affected by CVE-2021-47621), and 2.10.x of `springfox-swagger2` itself carries an unfixed medium "Improper Input Validation" issue (Snyk lists 2.9.2 as its latest non-vulnerable version). Both appeared as new Snyk findings on the earlier commits of this branch, which is why the final diff is a one-line change.

Note: `./gradlew compileJava` could not be run here — Maven Central returns HTTP 429 for `buildSrc` dependencies, and the Gradle 4.10.2 wrapper predates the JDKs available in this environment. The UI resources are served from `META-INF/resources` on the classpath in both versions, so `/swagger-ui.html` should be unchanged, but loading that page once after deploy is the sensible pre-merge check.


Link to Devin session: https://app.devin.ai/sessions/574b031ec6984da9b788d44f5257aeff
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/272?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->