### PR TITLE
Fix: Cross-site scripting in Swagger-UI

### DIFF
--- a/common-swagger/build.gradle
+++ b/common-swagger/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile ("io.springfox:springfox-swagger2:2.8.0") {
+    compile ("io.springfox:springfox-swagger2:2.10.0") {
         exclude group: "org.springframework"
     }
-    compile ("io.springfox:springfox-swagger-ui:2.8.0"){
+    compile ("io.springfox:springfox-swagger-ui:2.10.0"){
         exclude group: "org.springframework"
     }
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"

--- a/common-swagger/src/main/java/net/chrisrichardson/eventstore/examples/customersandorders/commonswagger/CommonSwaggerConfiguration.java
+++ b/common-swagger/src/main/java/net/chrisrichardson/eventstore/examples/customersandorders/commonswagger/CommonSwaggerConfiguration.java
@@ -10,14 +10,14 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.schema.WildcardType;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc;
 
 import java.util.concurrent.CompletableFuture;
 
 import static springfox.documentation.schema.AlternateTypeRules.newRule;
 
 @Configuration
-@EnableSwagger2
+@EnableSwagger2WebMvc
 public class CommonSwaggerConfiguration {
 
     @Bean


### PR DESCRIPTION
## Summary
Finding: **Cross-site scripting in Swagger-UI** (CVE-2019-17495) in **COG-GTM/ftgo-monolith**.

Fix approach: upgrade `io.springfox:springfox-swagger2` / `springfox-swagger-ui` from 2.8.0 to 2.10.0 so the served Swagger UI is the patched 3.23.11 bundle instead of 3.9.1, adjusting the config annotation that 2.10.0 renamed.

- `springfox-swagger-ui:2.8.0` ships `SwaggerUi-Version: 3.9.1` (per its jar manifest), below the patched Swagger UI 3.23.11; `2.10.0` ships `3.23.11`.
- 2.10.0 renamed the MVC entrypoint, so `@EnableSwagger2` → `@EnableSwagger2WebMvc` in `CommonSwaggerConfiguration`; the `Docket` bean is unchanged.

Verified `./gradlew :common-swagger:compileJava :ftgo-application:compileJava` succeeds with JDK 11 both before and after the change.


Link to Devin session: https://app.devin.ai/sessions/12c0d634b204465e94fea8b415e7f128
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/281?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->