### PR TITLE
Fix: Consumer payment tokens and delivery addresses transit the database link unencrypted with committed credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - mysql
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql/ftgo
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql/ftgo?useSSL=true&requireSSL=true&allowPublicKeyRetrieval=false
       SPRING_DATASOURCE_USERNAME: mysqluser
       SPRING_DATASOURCE_PASSWORD: mysqlpw
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.mysql.jdbc.Driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - mysql
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql/ftgo?useSSL=true&requireSSL=true&allowPublicKeyRetrieval=false
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql/ftgo?useSSL=${DB_USE_SSL:-true}&requireSSL=${DB_REQUIRE_SSL:-true}&allowPublicKeyRetrieval=false
       SPRING_DATASOURCE_USERNAME: mysqluser
       SPRING_DATASOURCE_PASSWORD: mysqlpw
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.mysql.jdbc.Driver

--- a/docs/DATA_PROTECTION.md
+++ b/docs/DATA_PROTECTION.md
@@ -1,0 +1,34 @@
+# Data protection: the application-to-database path
+
+The `orders` table holds regulated consumer data: `PaymentInformation.paymentToken` and the
+`DeliveryInformation` street/city/state/zip of the consumer (see
+`ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/Order.java`). Everything below applies to
+the connection that carries that data.
+
+## Transport
+
+The datasource URL in `ftgo-application/src/main/resources/application.properties` and the
+`SPRING_DATASOURCE_URL` in `docker-compose.yml` require TLS:
+
+```
+useSSL=true&requireSSL=true&allowPublicKeyRetrieval=false
+```
+
+`DB_USE_SSL` / `DB_REQUIRE_SSL` exist only so a local developer can opt out against a throwaway
+database. Do not set either to `false` in any environment that holds real consumer data, and do not
+re-enable `allowPublicKeyRetrieval`, which lets a party on the network path obtain the server public
+key during authentication.
+
+## Credentials
+
+`DB_USERNAME` / `DB_PASSWORD` (or `SPRING_DATASOURCE_USERNAME` / `SPRING_DATASOURCE_PASSWORD`) must
+be injected from the deployment's secret store. The values checked into this repository are local
+development defaults for the throwaway `docker-compose` MySQL instance only; they are not valid
+credentials for any environment holding real data, and no real credential may be committed here.
+
+## Logging
+
+`logging.level.org.hibernate.SQL=DEBUG` logs statement text with bound parameters replaced by `?`.
+Do not raise Hibernate binder logging (`org.hibernate.type.descriptor.sql`) to `TRACE` in an
+environment with real data: that logs parameter values, which would write payment tokens and
+delivery addresses into application logs.

--- a/ftgo-application/src/main/resources/application.properties
+++ b/ftgo-application/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=ftgo-application
 spring.jpa.generate-ddl=false
 logging.level.org.springframework.orm.jpa=INFO
 logging.level.org.hibernate.SQL=DEBUG
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo?useSSL=false&allowPublicKeyRetrieval=true
-spring.datasource.username=mysqluser
-spring.datasource.password=mysqlpw
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo?useSSL=${DB_USE_SSL:true}&requireSSL=${DB_REQUIRE_SSL:true}&allowPublicKeyRetrieval=false
+spring.datasource.username=${DB_USERNAME:mysqluser}
+spring.datasource.password=${DB_PASSWORD:mysqlpw}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Summary
Finding: **Consumer payment tokens and delivery addresses transit the database link unencrypted with committed credentials** (COMPLIANCE / NS terms data-flow gap) in **COG-GTM/ftgo-monolith**.

Fix approach: require TLS on the app-to-MySQL connection that carries the `orders` table's payment tokens and delivery addresses, stop advertising public-key retrieval, and make the datasource credentials injectable from the environment instead of being read straight from committed values.

```diff
- ...?useSSL=false&allowPublicKeyRetrieval=true
+ ...?useSSL=${DB_USE_SSL:true}&requireSSL=${DB_REQUIRE_SSL:true}&allowPublicKeyRetrieval=false
- spring.datasource.username=mysqluser
- spring.datasource.password=mysqlpw
+ spring.datasource.username=${DB_USERNAME:mysqluser}
+ spring.datasource.password=${DB_PASSWORD:mysqlpw}
```

`docker-compose.yml` overrides the URL via `SPRING_DATASOURCE_URL`, so the same TLS parameters are applied there too — otherwise the compose path would silently keep the old behavior.

`DB_USE_SSL` / `DB_REQUIRE_SSL` keep a local developer able to run against a throwaway database without TLS; the committed values remain local-dev defaults only. `docs/DATA_PROTECTION.md` records what data crosses this path, that those toggles must not be flipped where real consumer data exists, and that Hibernate binder logging must not be raised to `TRACE` (which would log parameter values, i.e. payment tokens and addresses).


Link to Devin session: https://app.devin.ai/sessions/12c0d634b204465e94fea8b415e7f128
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/283?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->