### PR TITLE
Fix: Unauthenticated API request log endpoints expose client IPs, query strings and internal error messages

### DIFF
--- a/ftgo-application/src/main/resources/application.properties
+++ b/ftgo-application/src/main/resources/application.properties
@@ -7,3 +7,7 @@ spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo?useSSL=false
 spring.datasource.username=mysqluser
 spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Read endpoints under /api/tracking are unauthenticated; keep them off unless
+# the service is reachable only from a trusted, authenticated network path.
+ftgo.api-tracking.endpoints.enabled=false

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingController.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingController.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping(path = "/api/tracking")
+@ConditionalOnProperty(name = "ftgo.api-tracking.endpoints.enabled", havingValue = "true")
 public class ApiTrackingController {
 
   private final ApiRequestLogRepository apiRequestLogRepository;


### PR DESCRIPTION
## Summary

Finding: **Unauthenticated API request log endpoints expose client IPs, query strings and internal error messages** in `COG-GTM/ftgo-monolith`.

`ApiTrackingController` served five unauthenticated `GET /api/tracking/**` endpoints that dump the whole `api_request_log` table (remote addresses, full query strings, user agents, raw exception messages). The repo has no Spring Security or other auth filter, so these were readable by anyone able to reach the service.

Fix approach: gate the controller behind an opt-in property so the endpoints are not registered unless an operator explicitly turns them on.

```java
@RestController
@RequestMapping(path = "/api/tracking")
+@ConditionalOnProperty(name = "ftgo.api-tracking.endpoints.enabled", havingValue = "true")
public class ApiTrackingController {
```

`ftgo.api-tracking.endpoints.enabled=false` is set explicitly in `application.properties` with a note that the endpoints are unauthenticated. Request tracking itself (interceptor + persistence) is unchanged; only the read API is gated.

Note: Maven Central returned HTTP 429 for this environment, so `./gradlew :ftgo-common:compileJava` could not resolve dependencies and the build was not run locally.


Link to Devin session: https://app.devin.ai/sessions/e83d0db8179142bd8cbf5c2a4a931efe
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/284?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->