### PR TITLE
Fix: Unbounded retention of client IP addresses and raw request query strings alongside courier geolocation data in the primary FTGO database

### DIFF
--- a/ftgo-application/src/main/resources/application.properties
+++ b/ftgo-application/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo?useSSL=false
 spring.datasource.username=mysqluser
 spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Request metadata is anonymized on write; rows are purged after this many days.
+ftgo.api-tracking.retention-days=7

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRedaction.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRedaction.java
@@ -30,8 +30,11 @@ public class ApiRequestLogRedaction {
     return Arrays.stream(queryString.split("&"))
             .map(parameter -> {
               int equals = parameter.indexOf('=');
-              String name = equals < 0 ? parameter : parameter.substring(0, equals);
-              return name.isEmpty() ? name : name + "=<redacted>";
+              if (equals < 0) {
+                return parameter.isEmpty() ? parameter : "<redacted>";
+              }
+              String name = parameter.substring(0, equals);
+              return name.isEmpty() ? "<redacted>" : name + "=<redacted>";
             })
             .collect(Collectors.joining("&"));
   }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRedaction.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRedaction.java
@@ -1,0 +1,42 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class ApiRequestLogRedaction {
+
+  private ApiRequestLogRedaction() {
+  }
+
+  public static String anonymizeRemoteAddr(String remoteAddr) {
+    if (remoteAddr == null || remoteAddr.isEmpty()) {
+      return null;
+    }
+    if (remoteAddr.contains(":")) {
+      String[] groups = remoteAddr.split(":");
+      return Arrays.stream(groups).limit(3).collect(Collectors.joining(":")) + "::/48";
+    }
+    int lastDot = remoteAddr.lastIndexOf('.');
+    if (lastDot < 0) {
+      return null;
+    }
+    return remoteAddr.substring(0, lastDot) + ".0/24";
+  }
+
+  public static String redactQueryString(String queryString) {
+    if (queryString == null || queryString.isEmpty()) {
+      return null;
+    }
+    return Arrays.stream(queryString.split("&"))
+            .map(parameter -> {
+              int equals = parameter.indexOf('=');
+              String name = equals < 0 ? parameter : parameter.substring(0, equals);
+              return name.isEmpty() ? name : name + "=<redacted>";
+            })
+            .collect(Collectors.joining("&"));
+  }
+
+  public static String describeException(Exception ex) {
+    return ex == null ? null : ex.getClass().getName();
+  }
+}

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
@@ -21,4 +21,6 @@ public interface ApiRequestLogRepository extends CrudRepository<ApiRequestLog, L
   @Query("SELECT a FROM ApiRequestLog a WHERE a.responseStatus >= 400 AND a.requestTimestamp >= :since ORDER BY a.requestTimestamp DESC")
   List<ApiRequestLog> findErrorsSince(@Param("since") LocalDateTime since);
 
+  long deleteByRequestTimestampBefore(LocalDateTime cutoff);
+
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -21,6 +22,8 @@ public interface ApiRequestLogRepository extends CrudRepository<ApiRequestLog, L
   @Query("SELECT a FROM ApiRequestLog a WHERE a.responseStatus >= 400 AND a.requestTimestamp >= :since ORDER BY a.requestTimestamp DESC")
   List<ApiRequestLog> findErrorsSince(@Param("since") LocalDateTime since);
 
-  long deleteByRequestTimestampBefore(LocalDateTime cutoff);
+  @Modifying
+  @Query("DELETE FROM ApiRequestLog a WHERE a.requestTimestamp < :cutoff")
+  int deleteOlderThan(@Param("cutoff") LocalDateTime cutoff);
 
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionService.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionService.java
@@ -1,0 +1,35 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+public class ApiRequestLogRetentionService {
+
+  private static final Logger logger = LoggerFactory.getLogger(ApiRequestLogRetentionService.class);
+
+  private final ApiRequestLogRepository apiRequestLogRepository;
+  private final int retentionDays;
+
+  public ApiRequestLogRetentionService(ApiRequestLogRepository apiRequestLogRepository,
+                                       @Value("${ftgo.api-tracking.retention-days:7}") int retentionDays) {
+    this.apiRequestLogRepository = apiRequestLogRepository;
+    this.retentionDays = retentionDays;
+  }
+
+  @Scheduled(fixedDelayString = "${ftgo.api-tracking.purge-interval-ms:3600000}")
+  @Transactional
+  public void purgeExpiredLogs() {
+    LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
+    long deleted = apiRequestLogRepository.deleteByRequestTimestampBefore(cutoff);
+    if (deleted > 0) {
+      logger.info("Purged {} api_request_log rows older than {}", deleted, cutoff);
+    }
+  }
+}

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionService.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionService.java
@@ -27,7 +27,7 @@ public class ApiRequestLogRetentionService {
   @Transactional
   public void purgeExpiredLogs() {
     LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
-    long deleted = apiRequestLogRepository.deleteByRequestTimestampBefore(cutoff);
+    int deleted = apiRequestLogRepository.deleteOlderThan(cutoff);
     if (deleted > 0) {
       logger.info("Purged {} api_request_log rows older than {}", deleted, cutoff);
     }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
@@ -2,10 +2,12 @@ package net.chrisrichardson.ftgo.common.tracking;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableScheduling
 public class ApiTrackingConfiguration implements WebMvcConfigurer {
 
   private final ApiRequestLogRepository apiRequestLogRepository;

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -40,8 +40,8 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
             correlationId,
             request.getMethod(),
             request.getRequestURI(),
-            request.getQueryString(),
-            request.getRemoteAddr(),
+            ApiRequestLogRedaction.redactQueryString(request.getQueryString()),
+            ApiRequestLogRedaction.anonymizeRemoteAddr(request.getRemoteAddr()),
             request.getHeader("User-Agent")
     );
 
@@ -65,7 +65,7 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
       long durationMs = System.currentTimeMillis() - startTime;
 
       if (ex != null) {
-        logEntry.complete(response.getStatus(), durationMs, ex.getMessage());
+        logEntry.complete(response.getStatus(), durationMs, ApiRequestLogRedaction.describeException(ex));
       } else {
         logEntry.complete(response.getStatus(), durationMs);
       }


### PR DESCRIPTION
## Summary

Finding: **Unbounded retention of client IP addresses and raw request query strings alongside courier geolocation data in the primary FTGO database** in `COG-GTM/ftgo-monolith` (NS-terms compliance gap, not an exploitable bug).

`api_request_log` lives in the same `ftgo` schema and behind the same DB credential as courier live coordinates and consumer delivery coordinates, while `ApiTrackingInterceptor` wrote client IPs, full query strings and raw exception messages verbatim with no expiry.

Fix approach: minimize what is persisted and bound how long it is kept.

```java
new ApiRequestLog(correlationId, method, uri,
-    request.getQueryString(), request.getRemoteAddr(), userAgent);
+    ApiRequestLogRedaction.redactQueryString(request.getQueryString()),   // "consumerId=<redacted>&token=<redacted>"
+    ApiRequestLogRedaction.anonymizeRemoteAddr(request.getRemoteAddr()), // "203.0.113.0/24"
+    userAgent);
...
-logEntry.complete(status, durationMs, ex.getMessage());
+logEntry.complete(status, durationMs, ex.getClass().getName());
```

`ApiRequestLogRetentionService` (`@Scheduled`, hourly by default) deletes rows older than `ftgo.api-tracking.retention-days` (default 7) via the new `deleteByRequestTimestampBefore`; `@EnableScheduling` is added on `ApiTrackingConfiguration`. Parameter *names* and coarse network origin are retained so the operational value of the tracking data (endpoint mix, error rates, latency) is unchanged.

Not addressed here: `SPRING_SLEUTH_SAMPLER_PROBABILITY: 1` in `docker-compose.yml` still exports 100% of spans (including request URIs) to the Zipkin collector — that egress path needs a separate decision on sampling and collector ownership.

Note: Maven Central returned HTTP 429 for this environment, so `./gradlew :ftgo-common:compileJava` could not resolve dependencies and the build was not run locally.


Link to Devin session: https://app.devin.ai/sessions/e83d0db8179142bd8cbf5c2a4a931efe
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/285?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->