### PR TITLE
Fix: MySQL Connectors takeover vulnerability

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compile 'mysql:mysql-connector-java:8.0.33'
+    compile 'com.mysql:mysql-connector-j:8.4.0'
     compile 'commons-lang:commons-lang:2.6'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.mysql:mysql-connector-j:8.4.0'
+    compile 'com.mysql:mysql-connector-j:8.2.0'
     compile 'commons-lang:commons-lang:2.6'
 }

--- a/ftgo-application/build.gradle
+++ b/ftgo-application/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
-    runtime 'mysql:mysql-connector-java:8.0.33'
+    runtime 'com.mysql:mysql-connector-j:8.4.0'
 
     testCompile project(":ftgo-end-to-end-tests-common")
 }

--- a/ftgo-application/build.gradle
+++ b/ftgo-application/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
-    runtime 'com.mysql:mysql-connector-j:8.4.0'
+    runtime 'com.mysql:mysql-connector-j:8.2.0'
 
     testCompile project(":ftgo-end-to-end-tests-common")
 }

--- a/ftgo-common/build.gradle
+++ b/ftgo-common/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.7"
 
-    compile 'mysql:mysql-connector-java:8.0.33'
+    compile 'com.mysql:mysql-connector-j:8.4.0'
 
     testCompile "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
 

--- a/ftgo-common/build.gradle
+++ b/ftgo-common/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.7"
 
-    compile 'com.mysql:mysql-connector-j:8.4.0'
+    compile 'com.mysql:mysql-connector-j:8.2.0'
 
     testCompile "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
 


### PR DESCRIPTION
## Summary

Finding: **MySQL Connectors takeover vulnerability** (CVE-2023-22102) in **COG-GTM/ftgo-monolith**.

Fix approach: replace the vulnerable `mysql:mysql-connector-java:8.0.33` coordinate with the patched artifact `com.mysql:mysql-connector-j:8.2.0` in every module that declares it.

```diff
-    'mysql:mysql-connector-java:8.0.33'
+    'com.mysql:mysql-connector-j:8.2.0'
```

applied in `buildSrc/build.gradle`, `ftgo-application/build.gradle`, `ftgo-common/build.gradle`.

`mysql:mysql-connector-java` is the retired coordinate (last release 8.0.33, which is affected by CVE-2023-22102 — high severity, network-exploitable takeover of Connector/J); Oracle publishes fixes only under `com.mysql:mysql-connector-j`, where the affected range ends at 8.1.0.

Version choice: 8.2.0 rather than a newer 8.x — it is the first release that fixes the CVE and the last one documented as usable "against MySQL Server version 5.7 and later", which this repo needs because `mysql/Dockerfile` pins `mysql:5.7.13` (8.4.0 requires server 8.0+).

No driver class change is needed: `ftgo-application/src/main/resources/application.properties` already uses `com.mysql.cj.jdbc.Driver`, the same class in the new artifact.

Verification: Gradle dependency resolution could not be run locally — Maven Central returned HTTP 429 for this VM, so `./gradlew` cannot resolve the dependency graph. Resolution/build verification is left to CI.

Advisories: https://nvd.nist.gov/vuln/detail/CVE-2023-22102, https://osv.dev/vulnerability/GHSA-m6vm-37g8-gqvh


Link to Devin session: https://app.devin.ai/sessions/e83d0db8179142bd8cbf5c2a4a931efe
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/287?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->