### PR TITLE
Fix: Unauthenticated API request log exposure via /api/tracking endpoints

### DIFF
--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -10,6 +11,9 @@ public class ApiTrackingConfiguration implements WebMvcConfigurer {
 
   private final ApiRequestLogRepository apiRequestLogRepository;
 
+  @Value("${ftgo.tracking.api.key:}")
+  private String trackingApiKey;
+
   public ApiTrackingConfiguration(ApiRequestLogRepository apiRequestLogRepository) {
     this.apiRequestLogRepository = apiRequestLogRepository;
   }
@@ -19,6 +23,8 @@ public class ApiTrackingConfiguration implements WebMvcConfigurer {
     registry.addInterceptor(apiTrackingInterceptor())
             .addPathPatterns("/**")
             .excludePathPatterns("/api/tracking/**", "/actuator/**");
+    registry.addInterceptor(new TrackingApiAuthInterceptor(trackingApiKey))
+            .addPathPatterns("/api/tracking/**");
   }
 
   @Bean

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/TrackingApiAuthInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/TrackingApiAuthInterceptor.java
@@ -1,0 +1,41 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * Guards the tracking API endpoints. Access requires the {@value #API_KEY_HEADER}
+ * header to match the key configured via {@code ftgo.tracking.api.key}. When no
+ * key is configured, all access is denied.
+ */
+public class TrackingApiAuthInterceptor implements HandlerInterceptor {
+
+  static final String API_KEY_HEADER = "X-Tracking-Api-Key";
+
+  private final String apiKey;
+
+  public TrackingApiAuthInterceptor(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+    if (apiKey == null || apiKey.isEmpty() || !constantTimeEquals(apiKey, request.getHeader(API_KEY_HEADER))) {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean constantTimeEquals(String expected, String actual) {
+    if (actual == null) {
+      return false;
+    }
+    return MessageDigest.isEqual(expected.getBytes(StandardCharsets.UTF_8), actual.getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## Summary

Finding: **Unauthenticated API request log exposure via /api/tracking endpoints** in **COG-GTM/ftgo-monolith**.

Fix approach: put an authentication gate in front of `ApiTrackingController` so the request-log data (URIs, query strings, client IPs, User-Agents, error messages) can no longer be read by anonymous callers.

`ApiTrackingConfiguration` now registers a second interceptor scoped to `/api/tracking/**`:

```java
registry.addInterceptor(new TrackingApiAuthInterceptor(trackingApiKey))
        .addPathPatterns("/api/tracking/**");
```

`TrackingApiAuthInterceptor` compares the `X-Tracking-Api-Key` header against `ftgo.tracking.api.key` using `MessageDigest.isEqual` (constant time) and returns 401 otherwise. The key has an empty default, and an empty/absent key denies every request — so the endpoints are closed by default and only open once an operator supplies a key (e.g. `FTGO_TRACKING_API_KEY` via the deployment environment). No key value is committed.


Link to Devin session: https://app.devin.ai/sessions/780ac1b98db441218d3e4aa04a608548
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/289?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=2">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=2" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->