### PR TITLE
Fix: Unbounded retention of unredacted client IPs and raw request query strings colocated with courier geolocation data

### DIFF
--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -20,5 +21,9 @@ public interface ApiRequestLogRepository extends CrudRepository<ApiRequestLog, L
 
   @Query("SELECT a FROM ApiRequestLog a WHERE a.responseStatus >= 400 AND a.requestTimestamp >= :since ORDER BY a.requestTimestamp DESC")
   List<ApiRequestLog> findErrorsSince(@Param("since") LocalDateTime since);
+
+  @Modifying
+  @Query("DELETE FROM ApiRequestLog a WHERE a.requestTimestamp < :cutoff")
+  int deleteLogsOlderThan(@Param("cutoff") LocalDateTime cutoff);
 
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionPurger.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionPurger.java
@@ -1,0 +1,35 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * Deletes API request log records older than the configured retention period
+ * ({@code ftgo.tracking.retention.days}, default 30 days).
+ */
+public class ApiRequestLogRetentionPurger {
+
+  private static final Logger logger = LoggerFactory.getLogger(ApiRequestLogRetentionPurger.class);
+
+  private final ApiRequestLogRepository apiRequestLogRepository;
+  private final int retentionDays;
+
+  public ApiRequestLogRetentionPurger(ApiRequestLogRepository apiRequestLogRepository, int retentionDays) {
+    this.apiRequestLogRepository = apiRequestLogRepository;
+    this.retentionDays = retentionDays;
+  }
+
+  @Scheduled(fixedDelayString = "${ftgo.tracking.retention.purge-interval-ms:3600000}")
+  @Transactional
+  public void purgeExpiredLogs() {
+    LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
+    int deleted = apiRequestLogRepository.deleteLogsOlderThan(cutoff);
+    if (deleted > 0) {
+      logger.info("Purged {} API request log entries older than {}", deleted, cutoff);
+    }
+  }
+}

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
@@ -1,14 +1,20 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableScheduling
 public class ApiTrackingConfiguration implements WebMvcConfigurer {
 
   private final ApiRequestLogRepository apiRequestLogRepository;
+
+  @Value("${ftgo.tracking.retention.days:30}")
+  private int retentionDays;
 
   public ApiTrackingConfiguration(ApiRequestLogRepository apiRequestLogRepository) {
     this.apiRequestLogRepository = apiRequestLogRepository;
@@ -24,5 +30,10 @@ public class ApiTrackingConfiguration implements WebMvcConfigurer {
   @Bean
   public ApiTrackingInterceptor apiTrackingInterceptor() {
     return new ApiTrackingInterceptor(apiRequestLogRepository);
+  }
+
+  @Bean
+  public ApiRequestLogRetentionPurger apiRequestLogRetentionPurger() {
+    return new ApiRequestLogRetentionPurger(apiRequestLogRepository, retentionDays);
   }
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -40,8 +40,8 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
             correlationId,
             request.getMethod(),
             request.getRequestURI(),
-            request.getQueryString(),
-            request.getRemoteAddr(),
+            redactQueryString(request.getQueryString()),
+            maskClientAddress(request.getRemoteAddr()),
             request.getHeader("User-Agent")
     );
 
@@ -83,5 +83,50 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     }
 
     MDC.remove("correlationId");
+  }
+
+  /**
+   * Masks the host-identifying portion of a client address: IPv4 addresses
+   * keep the first three octets, IPv6 addresses keep the first three groups.
+   */
+  static String maskClientAddress(String remoteAddr) {
+    if (remoteAddr == null || remoteAddr.isEmpty()) {
+      return remoteAddr;
+    }
+    if (remoteAddr.contains(":")) {
+      String[] groups = remoteAddr.split(":");
+      if (groups.length <= 3) {
+        return remoteAddr;
+      }
+      return groups[0] + ":" + groups[1] + ":" + groups[2] + "::";
+    }
+    int lastDot = remoteAddr.lastIndexOf('.');
+    if (lastDot < 0) {
+      return remoteAddr;
+    }
+    return remoteAddr.substring(0, lastDot) + ".0";
+  }
+
+  /**
+   * Keeps query parameter names but replaces their values, which can carry
+   * PII such as emails, addresses, or tokens.
+   */
+  static String redactQueryString(String queryString) {
+    if (queryString == null || queryString.isEmpty()) {
+      return queryString;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (String param : queryString.split("&")) {
+      if (sb.length() > 0) {
+        sb.append('&');
+      }
+      int eq = param.indexOf('=');
+      if (eq >= 0) {
+        sb.append(param, 0, eq).append("=REDACTED");
+      } else {
+        sb.append(param);
+      }
+    }
+    return sb.toString();
   }
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -87,18 +87,25 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
 
   /**
    * Masks the host-identifying portion of a client address: IPv4 addresses
-   * keep the first three octets, IPv6 addresses keep the first three groups.
+   * keep the first three octets, IPv6 addresses keep at most the first three
+   * groups before any {@code ::} compression, with the remainder elided.
    */
   static String maskClientAddress(String remoteAddr) {
     if (remoteAddr == null || remoteAddr.isEmpty()) {
       return remoteAddr;
     }
     if (remoteAddr.contains(":")) {
-      String[] groups = remoteAddr.split(":");
-      if (groups.length <= 3) {
-        return remoteAddr;
+      int doubleColon = remoteAddr.indexOf("::");
+      String head = doubleColon >= 0 ? remoteAddr.substring(0, doubleColon) : remoteAddr;
+      String[] groups = head.isEmpty() ? new String[0] : head.split(":");
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < Math.min(3, groups.length); i++) {
+        if (i > 0) {
+          sb.append(':');
+        }
+        sb.append(groups[i]);
       }
-      return groups[0] + ":" + groups[1] + ":" + groups[2] + "::";
+      return sb.append("::").toString();
     }
     int lastDot = remoteAddr.lastIndexOf('.');
     if (lastDot < 0) {


### PR DESCRIPTION
## Summary

Finding: **Unbounded retention of unredacted client IPs and raw request query strings colocated with courier geolocation data** (NS-compliance gap) in **COG-GTM/ftgo-monolith**.

Fix approach: minimize the personal data captured by the API tracking interceptor and bound its retention with a scheduled purge.

- `ApiTrackingInterceptor` now persists `maskClientAddress(remoteAddr)` (IPv4 truncated to /24, IPv6 to first 3 groups) and `redactQueryString(queryString)` (parameter names kept, values replaced with `REDACTED`) instead of raw values.
- New `ApiRequestLogRetentionPurger` (`@Scheduled`, hourly by default) deletes `api_request_log` rows older than `ftgo.tracking.retention.days` (default 30) via `ApiRequestLogRepository.deleteLogsOlderThan(cutoff)`.
- `ApiTrackingConfiguration` gains `@EnableScheduling` and wires the purger bean; purge interval configurable via `ftgo.tracking.retention.purge-interval-ms`.

Verified: `ftgo-common` tests and `ftgo-application:compileJava` pass.

Link to Devin session: https://app.devin.ai/sessions/780ac1b98db441218d3e4aa04a608548
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/290?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=2">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=2" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->