### PR TITLE
Fix: Unauthenticated /api/tracking endpoints expose request logs with client IPs and query strings

### DIFF
--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingController.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingController.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping(path = "/api/tracking")
+@ConditionalOnProperty(name = "ftgo.api-tracking.endpoints-enabled", havingValue = "true")
 public class ApiTrackingController {
 
   private final ApiRequestLogRepository apiRequestLogRepository;

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -40,7 +40,7 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
             correlationId,
             request.getMethod(),
             request.getRequestURI(),
-            request.getQueryString(),
+            redactQueryString(request.getQueryString()),
             request.getRemoteAddr(),
             request.getHeader("User-Agent")
     );
@@ -50,6 +50,21 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     logger.info("[{}] {} {} started", correlationId, request.getMethod(), request.getRequestURI());
 
     return true;
+  }
+
+  private static String redactQueryString(String queryString) {
+    if (queryString == null || queryString.isEmpty()) {
+      return queryString;
+    }
+    StringBuilder redacted = new StringBuilder();
+    for (String parameter : queryString.split("&")) {
+      if (redacted.length() > 0) {
+        redacted.append('&');
+      }
+      int separator = parameter.indexOf('=');
+      redacted.append(separator < 0 ? parameter : parameter.substring(0, separator) + "=REDACTED");
+    }
+    return redacted.toString();
   }
 
   @Override


### PR DESCRIPTION
## Summary

Finding: **Unauthenticated /api/tracking endpoints expose request logs with client IPs and query strings** (COG-GTM/ftgo-monolith).

The `/api/tracking/**` read endpoints returned every persisted `api_request_log` row — client IP, raw query string, user agent, exception message — to any unauthenticated caller, and the repo has no authentication/authorization layer at all. Fix approach: make the query endpoints opt-in and stop persisting raw query-parameter values.

- `ApiTrackingController` is now `@ConditionalOnProperty("ftgo.api-tracking.endpoints-enabled" == "true")`, so `/logs`, `/logs/errors`, `/logs/search`, `/logs/{correlationId}` and `/stats` are absent unless an operator explicitly enables them (and can then front them with auth). Interception/persistence itself is unchanged.
- `ApiTrackingInterceptor` records `redactQueryString(request.getQueryString())` — parameter names are kept, values become `REDACTED`:

```
"consumerId=42&email=a@b.com" -> "consumerId=REDACTED&email=REDACTED"
```

`./gradlew :ftgo-common:compileJava :ftgo-common:test` passes.


Link to Devin session: https://app.devin.ai/sessions/377224399010460e90d9acbc0d01c15c
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/291?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->