### PR TITLE
Fix: Cross-site scripting in Swagger-UI

### DIFF
--- a/common-swagger/build.gradle
+++ b/common-swagger/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile ("io.springfox:springfox-swagger2:2.8.0") {
+    compile ("io.springfox:springfox-swagger2:2.10.5") {
         exclude group: "org.springframework"
     }
-    compile ("io.springfox:springfox-swagger-ui:2.8.0"){
+    compile ("io.springfox:springfox-swagger-ui:2.10.5"){
         exclude group: "org.springframework"
     }
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"

--- a/common-swagger/build.gradle
+++ b/common-swagger/build.gradle
@@ -1,8 +1,5 @@
 dependencies {
-    compile ("io.springfox:springfox-swagger2:2.10.5") {
-        exclude group: "org.springframework"
-    }
-    compile ("io.springfox:springfox-swagger-ui:2.10.5"){
+    compile ("io.springfox:springfox-swagger2:2.8.0") {
         exclude group: "org.springframework"
     }
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"

--- a/common-swagger/src/main/java/net/chrisrichardson/eventstore/examples/customersandorders/commonswagger/CommonSwaggerConfiguration.java
+++ b/common-swagger/src/main/java/net/chrisrichardson/eventstore/examples/customersandorders/commonswagger/CommonSwaggerConfiguration.java
@@ -10,14 +10,14 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.schema.WildcardType;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc;
 
 import java.util.concurrent.CompletableFuture;
 
 import static springfox.documentation.schema.AlternateTypeRules.newRule;
 
 @Configuration
-@EnableSwagger2
+@EnableSwagger2WebMvc
 public class CommonSwaggerConfiguration {
 
     @Bean

--- a/common-swagger/src/main/java/net/chrisrichardson/eventstore/examples/customersandorders/commonswagger/CommonSwaggerConfiguration.java
+++ b/common-swagger/src/main/java/net/chrisrichardson/eventstore/examples/customersandorders/commonswagger/CommonSwaggerConfiguration.java
@@ -10,14 +10,14 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.schema.WildcardType;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.util.concurrent.CompletableFuture;
 
 import static springfox.documentation.schema.AlternateTypeRules.newRule;
 
 @Configuration
-@EnableSwagger2WebMvc
+@EnableSwagger2
 public class CommonSwaggerConfiguration {
 
     @Bean

--- a/open-swagger-uis.sh
+++ b/open-swagger-uis.sh
@@ -2,5 +2,5 @@
 
 
 for port in 8081 ; do
-    open http://${DOCKER_HOST_IP?}:$port/swagger-ui.html
+    open http://${DOCKER_HOST_IP?}:$port/v2/api-docs
 done

--- a/show-swagger-ui-urls.sh
+++ b/show-swagger-ui-urls.sh
@@ -2,4 +2,4 @@
 
 ./wait-for-services.sh
 
-echo for API - open http://${DOCKER_HOST_IP?}:8081/swagger-ui.html
+echo for API - open http://${DOCKER_HOST_IP?}:8081/v2/api-docs


### PR DESCRIPTION
## Summary

Finding: **Cross-site scripting in Swagger-UI** (CVE-2019-17495 / GHSA-c427-hjc3-wrfw) in `COG-GTM/ftgo-monolith`.

Fix approach: drop the `io.springfox:springfox-swagger-ui` dependency so the vulnerable bundled Swagger UI is no longer packaged or routable, keeping `springfox-swagger2` (unchanged at 2.8.0) so the OpenAPI spec is still served at `/v2/api-docs`.

The first attempt in this PR upgraded springfox to 2.10.5 (the advisory's patched line). Runtime verification showed that does not work on this app's pinned Spring Boot 2.0.3 / Spring 5.0.7: springfox 2.10.x no longer exposes a `TypeResolver` bean (startup failure in `CommonSwaggerConfiguration`), and after working around that the springfox controllers were never registered — `/v2/api-docs` and `/swagger-resources` returned 404 while only the static `swagger-ui.html` shell served. It also pulled in `classgraph:4.1.7` (CVE-2021-47621), which is the likely cause of the Snyk PR check failure. That upgrade is reverted here; `CommonSwaggerConfiguration.java` is back to its original contents.

```diff
 dependencies {
     compile ("io.springfox:springfox-swagger2:2.8.0") { exclude group: "org.springframework" }
-    compile ("io.springfox:springfox-swagger-ui:2.8.0"){ exclude group: "org.springframework" }
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 }
```

`open-swagger-uis.sh` / `show-swagger-ui-urls.sh` now point at `/v2/api-docs` instead of the removed `/swagger-ui.html`.

Verified by booting `ftgo-application` against the docker-compose MySQL on JDK 8:

| endpoint | master | this branch |
| --- | --- | --- |
| `/swagger-ui.html` | 200 | 404 |
| `/v2/api-docs` | 200 | 200 |

`springfox-swagger-ui` is no longer present in the built `ftgo-application.jar`.

Note: the interactive UI is gone; consumers read the spec from `/v2/api-docs` (or point an externally-hosted, up-to-date Swagger UI at it). Say the word if you'd rather keep a UI, which would require moving off springfox's bundled one.


Link to Devin session: https://app.devin.ai/sessions/377224399010460e90d9acbc0d01c15c
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/292?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->