### PR TITLE
Fix: Deeply nested json in jackson-databind (CVE-2020-36518)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ subprojects {
 
     group = "net.chrisrichardson.ftgo"
 
+    // Overrides the Jackson version managed by the Spring Boot BOM so the
+    // resolved version is not downgraded for modules using dependency management.
+    ext['jackson.version'] = jacksonVersion
+
     repositories {
         mavenCentral()
         jcenter()

--- a/ftgo-common/build.gradle
+++ b/ftgo-common/build.gradle
@@ -5,10 +5,10 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.7'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.7'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.7"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
 
     compile 'mysql:mysql-connector-java:8.0.33'
 

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/MoneyModule.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/MoneyModule.java
@@ -30,7 +30,7 @@ public class MoneyModule extends SimpleModule {
         else
           return new Money(str);
       } else
-        throw ctxt.mappingException(getValueClass());
+        return (Money) ctxt.handleUnexpectedToken(Money.class, jp);
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ restAssuredVersion=2.9.0
 springDependencyManagementPluginVersion=1.0.3.RELEASE
 eventuateUtilVersion=0.1.0.RELEASE
 
-jacksonVersion=2.13.5
+jacksonVersion=2.17.2
 
 dockerComposePluginVersion=0.6.6
 micrometerVersion=1.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ restAssuredVersion=2.9.0
 springDependencyManagementPluginVersion=1.0.3.RELEASE
 eventuateUtilVersion=0.1.0.RELEASE
 
-jacksonVersion=2.17.2
+jacksonVersion=2.18.10
 
 dockerComposePluginVersion=0.6.6
 micrometerVersion=1.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,7 @@ restAssuredVersion=2.9.0
 springDependencyManagementPluginVersion=1.0.3.RELEASE
 eventuateUtilVersion=0.1.0.RELEASE
 
+jacksonVersion=2.13.5
+
 dockerComposePluginVersion=0.6.6
 micrometerVersion=1.0.4


### PR DESCRIPTION
## Summary

Finding: **Deeply nested json in jackson-databind (CVE-2020-36518)** in **COG-GTM/ftgo-monolith**.

Fix approach: bump the whole Jackson stack from the end-of-life 2.9.7 pin to 2.18.10, driven by a single `jacksonVersion` property.

`ftgo-common/build.gradle` pinned `jackson-core`/`jackson-databind`/`jackson-datatype-jsr310` at 2.9.7, which is vulnerable to an unauthenticated StackOverflow DoS on any `@RequestBody` endpoint. Because `ftgo-application` (and `ftgo-order-service`) apply `io.spring.dependency-management`, the Spring Boot 2.0.3 BOM would otherwise pull the transitive `jackson-databind` back down to 2.9.6, so the root build also overrides the managed version:

```groovy
// build.gradle (subprojects)
ext['jackson.version'] = jacksonVersion   // 2.18.10
```

Why 2.18.10 and not 2.13.x: jackson-core < 2.15.0 is affected by CVE-2025-52999 (GHSA-h46c-h94j-95f3), the same deeply-nested-input StackOverflow class of bug, so stopping at 2.13.5 leaves the streaming parser unfixed. The 2.14–2.17 lines still carry open databind advisories (GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f, GHSA-hgj6-7826-r7m5, GHSA-5jmj-h7xm-6q6v), all fixed in 2.18.8/2.18.9; 2.18.10 is the current 2.18 patch and OSV reports no known advisories for either `jackson-core:2.18.10` or `jackson-databind:2.18.10`.

`ctxt.mappingException(Class)` was removed in Jackson 2.15, so `MoneyModule` now uses the supported `ctxt.handleUnexpectedToken(Money.class, jp)`, which throws the same `JsonMappingException` subclass.

Verified with `./gradlew :ftgo-application:dependencies --configuration runtimeClasspath`: `jackson-databind:2.9.6 -> 2.18.10` throughout. `./gradlew :ftgo-application:bootJar`, the service modules' `classes` tasks, and `./gradlew :ftgo-common:test --tests '*MoneySerializationTest*'` succeed; full `testClasses` still fails on the pre-existing unresolvable `io.eventuate.util:eventuate-util-test:0.1.0.RELEASE` (fails identically on `master`).

Link to Devin session: https://app.devin.ai/sessions/b3ef5176374943e6945c009334c83ee2
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/293?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->