### PR TITLE
Fix: Unauthenticated API request-log endpoints expose client IP addresses and request metadata

### DIFF
--- a/ftgo-application/src/main/resources/application.properties
+++ b/ftgo-application/src/main/resources/application.properties
@@ -2,6 +2,10 @@ spring.application.name=ftgo-application
 
 spring.jpa.generate-ddl=false
 logging.level.org.springframework.orm.jpa=INFO
+
+ftgo.api-tracking.query-api.enabled=false
+ftgo.api-tracking.retention-days=30
+
 logging.level.org.hibernate.SQL=DEBUG
 spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo?useSSL=false&allowPublicKeyRetrieval=true
 spring.datasource.username=mysqluser

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLog.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLog.java
@@ -14,11 +14,9 @@ public class ApiRequestLog {
   private String correlationId;
   private String httpMethod;
   private String requestUri;
-  private String queryString;
   private Integer responseStatus;
   private Long durationMs;
   private String remoteAddr;
-  private String userAgent;
 
   @Column(length = 4000)
   private String errorMessage;
@@ -29,13 +27,11 @@ public class ApiRequestLog {
   }
 
   public ApiRequestLog(String correlationId, String httpMethod, String requestUri,
-                       String queryString, String remoteAddr, String userAgent) {
+                       String remoteAddr) {
     this.correlationId = correlationId;
     this.httpMethod = httpMethod;
     this.requestUri = requestUri;
-    this.queryString = queryString;
     this.remoteAddr = remoteAddr;
-    this.userAgent = userAgent;
     this.requestTimestamp = LocalDateTime.now();
   }
 
@@ -66,10 +62,6 @@ public class ApiRequestLog {
     return requestUri;
   }
 
-  public String getQueryString() {
-    return queryString;
-  }
-
   public Integer getResponseStatus() {
     return responseStatus;
   }
@@ -80,10 +72,6 @@ public class ApiRequestLog {
 
   public String getRemoteAddr() {
     return remoteAddr;
-  }
-
-  public String getUserAgent() {
-    return userAgent;
   }
 
   public String getErrorMessage() {

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRepository.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -20,5 +21,9 @@ public interface ApiRequestLogRepository extends CrudRepository<ApiRequestLog, L
 
   @Query("SELECT a FROM ApiRequestLog a WHERE a.responseStatus >= 400 AND a.requestTimestamp >= :since ORDER BY a.requestTimestamp DESC")
   List<ApiRequestLog> findErrorsSince(@Param("since") LocalDateTime since);
+
+  @Modifying
+  @Query("DELETE FROM ApiRequestLog a WHERE a.requestTimestamp < :cutoff")
+  int deleteLogsOlderThan(@Param("cutoff") LocalDateTime cutoff);
 
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionJob.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiRequestLogRetentionJob.java
@@ -1,0 +1,33 @@
+package net.chrisrichardson.ftgo.common.tracking;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+public class ApiRequestLogRetentionJob {
+
+  private static final Logger logger = LoggerFactory.getLogger(ApiRequestLogRetentionJob.class);
+
+  private final ApiRequestLogRepository apiRequestLogRepository;
+
+  @Value("${ftgo.api-tracking.retention-days:30}")
+  private int retentionDays;
+
+  public ApiRequestLogRetentionJob(ApiRequestLogRepository apiRequestLogRepository) {
+    this.apiRequestLogRepository = apiRequestLogRepository;
+  }
+
+  @Transactional
+  @Scheduled(fixedDelayString = "${ftgo.api-tracking.retention-check-interval-ms:3600000}")
+  public void deleteExpiredLogs() {
+    LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
+    int deleted = apiRequestLogRepository.deleteLogsOlderThan(cutoff);
+    if (deleted > 0) {
+      logger.info("Deleted {} API request log entries older than {}", deleted, cutoff);
+    }
+  }
+}

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingConfiguration.java
@@ -2,10 +2,12 @@ package net.chrisrichardson.ftgo.common.tracking;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableScheduling
 public class ApiTrackingConfiguration implements WebMvcConfigurer {
 
   private final ApiRequestLogRepository apiRequestLogRepository;
@@ -24,5 +26,10 @@ public class ApiTrackingConfiguration implements WebMvcConfigurer {
   @Bean
   public ApiTrackingInterceptor apiTrackingInterceptor() {
     return new ApiTrackingInterceptor(apiRequestLogRepository);
+  }
+
+  @Bean
+  public ApiRequestLogRetentionJob apiRequestLogRetentionJob() {
+    return new ApiRequestLogRetentionJob(apiRequestLogRepository);
   }
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingController.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingController.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping(path = "/api/tracking")
+@ConditionalOnProperty(name = "ftgo.api-tracking.query-api.enabled", havingValue = "true")
 public class ApiTrackingController {
 
   private final ApiRequestLogRepository apiRequestLogRepository;

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -40,9 +40,7 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
             correlationId,
             request.getMethod(),
             request.getRequestURI(),
-            request.getQueryString(),
-            request.getRemoteAddr(),
-            request.getHeader("User-Agent")
+            anonymizeClientAddress(request.getRemoteAddr())
     );
 
     request.setAttribute(LOG_ENTRY_ATTR, logEntry);
@@ -83,5 +81,28 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     }
 
     MDC.remove("correlationId");
+  }
+
+  /**
+   * Reduces a client address to its network prefix so that individual clients cannot be
+   * identified from the persisted request log.
+   */
+  static String anonymizeClientAddress(String remoteAddr) {
+    if (remoteAddr == null || remoteAddr.isEmpty()) {
+      return null;
+    }
+    if (remoteAddr.indexOf(':') >= 0) {
+      String[] groups = remoteAddr.split(":");
+      StringBuilder prefix = new StringBuilder();
+      for (int i = 0; i < 3 && i < groups.length; i++) {
+        prefix.append(groups[i]).append(':');
+      }
+      return prefix.append(':').toString();
+    }
+    int lastDot = remoteAddr.lastIndexOf('.');
+    if (lastDot < 0) {
+      return null;
+    }
+    return remoteAddr.substring(0, lastDot) + ".0";
   }
 }

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -8,6 +8,8 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.UUID;
 
 public class ApiTrackingInterceptor implements HandlerInterceptor {
@@ -91,18 +93,15 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     if (remoteAddr == null || remoteAddr.isEmpty()) {
       return null;
     }
-    if (remoteAddr.indexOf(':') >= 0) {
-      String[] groups = remoteAddr.split(":");
-      StringBuilder prefix = new StringBuilder();
-      for (int i = 0; i < 3 && i < groups.length; i++) {
-        prefix.append(groups[i]).append(':');
+    try {
+      byte[] address = InetAddress.getByName(remoteAddr).getAddress();
+      int retainedBytes = address.length == 4 ? 3 : 8;
+      for (int i = retainedBytes; i < address.length; i++) {
+        address[i] = 0;
       }
-      return prefix.append(':').toString();
-    }
-    int lastDot = remoteAddr.lastIndexOf('.');
-    if (lastDot < 0) {
+      return InetAddress.getByAddress(address).getHostAddress();
+    } catch (UnknownHostException e) {
       return null;
     }
-    return remoteAddr.substring(0, lastDot) + ".0";
   }
 }

--- a/ftgo-flyway/src/main/resources/db/migration/V3__drop_api_request_log_client_identifiers.sql
+++ b/ftgo-flyway/src/main/resources/db/migration/V3__drop_api_request_log_client_identifiers.sql
@@ -1,0 +1,6 @@
+use ftgo;
+
+-- Client identifiers are no longer collected: query strings can carry personal data and
+-- user agents identify individual clients.
+ALTER TABLE api_request_log DROP COLUMN query_string;
+ALTER TABLE api_request_log DROP COLUMN user_agent;


### PR DESCRIPTION
## Summary

**Finding:** Unauthenticated API request-log endpoints expose client IP addresses and request metadata (COMPLIANCE / HIGH)
**Repository:** COG-GTM/ftgo-monolith

**Fix approach:** stop collecting client-identifying data in `ApiRequestLog`, coarsen the stored client address, disable the `/api/tracking` query API by default, and expire stored request logs.

What changed:

- `ApiRequestLog` no longer has `queryString`/`userAgent` fields or getters; the constructor drops to `(correlationId, httpMethod, requestUri, remoteAddr)`. `V3__drop_api_request_log_client_identifiers.sql` drops the corresponding columns.
- `ApiTrackingInterceptor` stores `anonymizeClientAddress(request.getRemoteAddr())` — IPv4 is reduced to its /24 (`203.0.113.7` -> `203.0.113.0`), IPv6 to a short prefix — so persisted rows cannot identify an individual client.
- `ApiTrackingController` is now `@ConditionalOnProperty("ftgo.api-tracking.query-api.enabled", havingValue = "true")`, so the unauthenticated `/api/tracking/**` read endpoints are not registered unless explicitly enabled; `application.properties` sets the default to `false`.
- `ApiRequestLogRetentionJob` (hourly, `ftgo.api-tracking.retention-days`, default 30) deletes expired rows via a new `deleteLogsOlderThan` repository query, so logs are no longer retained indefinitely.


Link to Devin session: https://app.devin.ai/sessions/b3ef5176374943e6945c009334c83ee2
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/294?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->