### PR TITLE
Fix: Log injection and MDC poisoning via unvalidated X-Correlation-ID request header

### DIFF
--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingInterceptor.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 public class ApiTrackingInterceptor implements HandlerInterceptor {
 
@@ -16,6 +17,7 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
   private static final String CORRELATION_ID_HEADER = "X-Correlation-ID";
   private static final String START_TIME_ATTR = "apiTracking.startTime";
   private static final String LOG_ENTRY_ATTR = "apiTracking.logEntry";
+  private static final Pattern SAFE_CORRELATION_ID = Pattern.compile("[A-Za-z0-9_-]{1,64}");
 
   private final ApiRequestLogRepository apiRequestLogRepository;
 
@@ -28,10 +30,7 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     long startTime = System.currentTimeMillis();
     request.setAttribute(START_TIME_ATTR, startTime);
 
-    String correlationId = request.getHeader(CORRELATION_ID_HEADER);
-    if (correlationId == null || correlationId.isEmpty()) {
-      correlationId = UUID.randomUUID().toString();
-    }
+    String correlationId = sanitizeCorrelationId(request.getHeader(CORRELATION_ID_HEADER));
 
     MDC.put("correlationId", correlationId);
     response.setHeader(CORRELATION_ID_HEADER, correlationId);
@@ -83,5 +82,12 @@ public class ApiTrackingInterceptor implements HandlerInterceptor {
     }
 
     MDC.remove("correlationId");
+  }
+
+  private static String sanitizeCorrelationId(String headerValue) {
+    if (headerValue == null || !SAFE_CORRELATION_ID.matcher(headerValue).matches()) {
+      return UUID.randomUUID().toString();
+    }
+    return headerValue;
   }
 }


### PR DESCRIPTION
## Summary

Finding: **Log injection and MDC poisoning via unvalidated X-Correlation-ID request header** — repo `COG-GTM/ftgo-monolith`.

`ApiTrackingInterceptor` used any non-empty `X-Correlation-ID` header verbatim, so a CRLF-bearing header value was written straight into the application log, the SLF4J MDC, the `X-Correlation-ID` response header and `api_request_log.correlation_id` — letting an unauthenticated caller forge log records (CWE-117).

Fix approach: accept the inbound header only when it matches a safe correlation-id shape, otherwise fall back to the generated UUID.

```java
- String correlationId = request.getHeader(CORRELATION_ID_HEADER);
- if (correlationId == null || correlationId.isEmpty()) correlationId = UUID.randomUUID().toString();
+ String correlationId = sanitizeCorrelationId(request.getHeader(CORRELATION_ID_HEADER));
+ // SAFE_CORRELATION_ID = [A-Za-z0-9_-]{1,64}; non-matching values are replaced with a fresh UUID
```

Client-supplied UUIDs (the documented use case for header propagation) still pass through unchanged.


Link to Devin session: https://app.devin.ai/sessions/455009dc4d2443539e2d6f2ce9e06931
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/298?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->