### PR TITLE
Fix: Courier real-time GPS coordinates and home address served to any caller with no privilege boundary

### DIFF
--- a/ftgo-courier-service-api/src/main/java/net/chrisrichardson/ftgo/courierservice/api/CourierWorkloadResponse.java
+++ b/ftgo-courier-service-api/src/main/java/net/chrisrichardson/ftgo/courierservice/api/CourierWorkloadResponse.java
@@ -7,21 +7,16 @@ public class CourierWorkloadResponse {
   private long courierId;
   private int activeDeliveries;
   private boolean available;
-  private Double currentLatitude;
-  private Double currentLongitude;
   private LocalDateTime lastLocationUpdate;
 
   public CourierWorkloadResponse() {
   }
 
   public CourierWorkloadResponse(long courierId, int activeDeliveries, boolean available,
-                                 Double currentLatitude, Double currentLongitude,
                                  LocalDateTime lastLocationUpdate) {
     this.courierId = courierId;
     this.activeDeliveries = activeDeliveries;
     this.available = available;
-    this.currentLatitude = currentLatitude;
-    this.currentLongitude = currentLongitude;
     this.lastLocationUpdate = lastLocationUpdate;
   }
 
@@ -47,22 +42,6 @@ public class CourierWorkloadResponse {
 
   public void setAvailable(boolean available) {
     this.available = available;
-  }
-
-  public Double getCurrentLatitude() {
-    return currentLatitude;
-  }
-
-  public void setCurrentLatitude(Double currentLatitude) {
-    this.currentLatitude = currentLatitude;
-  }
-
-  public Double getCurrentLongitude() {
-    return currentLongitude;
-  }
-
-  public void setCurrentLongitude(Double currentLongitude) {
-    this.currentLongitude = currentLongitude;
   }
 
   public LocalDateTime getLastLocationUpdate() {

--- a/ftgo-courier-service/src/main/java/net/chrisrichardson/ftgo/courierservice/web/CourierController.java
+++ b/ftgo-courier-service/src/main/java/net/chrisrichardson/ftgo/courierservice/web/CourierController.java
@@ -51,8 +51,6 @@ public class CourierController {
             courier.getId(),
             courier.getActiveDeliveryCount(),
             courier.isAvailable(),
-            courier.getCurrentLatitude(),
-            courier.getCurrentLongitude(),
             courier.getLastLocationUpdate()
     );
     return new ResponseEntity<>(response, HttpStatus.OK);

--- a/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/Courier.java
+++ b/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/Courier.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import net.chrisrichardson.ftgo.common.Address;
 import net.chrisrichardson.ftgo.common.PersonName;
 import org.hibernate.annotations.DynamicUpdate;
@@ -81,14 +82,17 @@ public class Courier {
     return name;
   }
 
+  @JsonIgnore
   public Address getAddress() {
     return address;
   }
 
+  @JsonIgnore
   public Double getCurrentLatitude() {
     return currentLatitude;
   }
 
+  @JsonIgnore
   public Double getCurrentLongitude() {
     return currentLongitude;
   }


### PR DESCRIPTION
## Summary

Finding: `[COMPLIANCE] [HIGH] Courier real-time GPS coordinates and home address served to any caller with no privilege boundary`
Repo: COG-GTM/ftgo-monolith

Fix approach: stop serializing courier home address and precise GPS coordinates in the courier HTTP responses, so worker location data stays internal to dispatch logic instead of being readable by any caller of `GET /couriers/{id}` and `GET /couriers/{id}/workload`.

- `Courier`: `@JsonIgnore` on `getAddress()`, `getCurrentLatitude()`, `getCurrentLongitude()` — the entity is returned directly by the controller, so these fields were serialized verbatim. Assignment logic (`DistanceOptimizedCourierAssignmentStrategy`, `OrderService`) calls the getters in-process and is unaffected.
- `CourierWorkloadResponse`: dropped `currentLatitude`/`currentLongitude` fields and accessors; `lastLocationUpdate`, workload count and availability (what dispatch actually needs) are retained.

```java
new CourierWorkloadResponse(id, activeDeliveries, available,
-    currentLatitude, currentLongitude, lastLocationUpdate)
+    lastLocationUpdate)
```

Pre-existing `ftgo-order-service` `OrderControllerTest` failures reproduce on `master` unchanged.


Link to Devin session: https://app.devin.ai/sessions/455009dc4d2443539e2d6f2ce9e06931
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/300?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->