### PR TITLE
[STORY-1] SLA breach detection endpoint for ops dashboard

### DIFF
--- a/ftgo-application/src/main/resources/application.properties
+++ b/ftgo-application/src/main/resources/application.properties
@@ -7,3 +7,10 @@ spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo?useSSL=false
 spring.datasource.username=mysqluser
 spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+ftgo.sla.default-threshold-minutes=30
+ftgo.sla.state-threshold-minutes.APPROVED=10
+ftgo.sla.state-threshold-minutes.ACCEPTED=15
+ftgo.sla.state-threshold-minutes.PREPARING=30
+ftgo.sla.state-threshold-minutes.READY_FOR_PICKUP=15
+ftgo.sla.state-threshold-minutes.PICKED_UP=45

--- a/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/Order.java
+++ b/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/Order.java
@@ -45,6 +45,7 @@ public class Order {
   @AttributeOverride(name="amount", column = @Column(name="order_minimum"))
   private Money orderMinimum = new Money(Integer.MAX_VALUE);
 
+  private LocalDateTime createdTime;
   private LocalDateTime readyBy;
   private LocalDateTime acceptTime;
   private LocalDateTime preparingTime;
@@ -63,6 +64,7 @@ public class Order {
     this.restaurant = restaurant;
     this.orderLineItems = new OrderLineItems(orderLineItems);
     this.orderState = APPROVED;
+    this.createdTime = LocalDateTime.now();
   }
 
   public Long getId() {
@@ -184,6 +186,52 @@ public class Order {
 
   public Courier getAssignedCourier() {
     return assignedCourier;
+  }
+
+  public LocalDateTime getCreatedTime() {
+    return createdTime;
+  }
+
+  public LocalDateTime getAcceptTime() {
+    return acceptTime;
+  }
+
+  public LocalDateTime getPreparingTime() {
+    return preparingTime;
+  }
+
+  public LocalDateTime getReadyForPickupTime() {
+    return readyForPickupTime;
+  }
+
+  public LocalDateTime getPickedUpTime() {
+    return pickedUpTime;
+  }
+
+  public LocalDateTime getDeliveredTime() {
+    return deliveredTime;
+  }
+
+  /**
+   * The time at which this order entered the state it is currently in, or null when unknown.
+   */
+  public LocalDateTime getStateEnteredTime() {
+    switch (orderState) {
+      case APPROVED:
+        return createdTime;
+      case ACCEPTED:
+        return acceptTime;
+      case PREPARING:
+        return preparingTime;
+      case READY_FOR_PICKUP:
+        return readyForPickupTime;
+      case PICKED_UP:
+        return pickedUpTime;
+      case DELIVERED:
+        return deliveredTime;
+      default:
+        return null;
+    }
   }
 
   public void noteDelivered() {

--- a/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/OrderRepository.java
+++ b/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/OrderRepository.java
@@ -1,6 +1,8 @@
 package net.chrisrichardson.ftgo.domain;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -8,5 +10,6 @@ import java.util.List;
 public interface OrderRepository extends CrudRepository<Order, Long> {
   List<Order> findAllByConsumerId(Long consumerId);
 
-  List<Order> findAllByOrderStateIn(Collection<OrderState> orderStates);
+  @Query("select o from Order o left join fetch o.restaurant where o.orderState in :orderStates")
+  List<Order> findAllByOrderStateIn(@Param("orderStates") Collection<OrderState> orderStates);
 }

--- a/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/OrderRepository.java
+++ b/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/OrderRepository.java
@@ -2,8 +2,11 @@ package net.chrisrichardson.ftgo.domain;
 
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface OrderRepository extends CrudRepository<Order, Long> {
   List<Order> findAllByConsumerId(Long consumerId);
+
+  List<Order> findAllByOrderStateIn(Collection<OrderState> orderStates);
 }

--- a/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/OrderState.java
+++ b/ftgo-domain/src/main/java/net/chrisrichardson/ftgo/domain/OrderState.java
@@ -1,7 +1,31 @@
 package net.chrisrichardson.ftgo.domain;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
 public enum OrderState {
   APPROVED,
   ACCEPTED, PREPARING, READY_FOR_PICKUP, PICKED_UP, DELIVERED,
   CANCELLED,
+  ;
+
+  private static final EnumSet<OrderState> TERMINAL_STATES = EnumSet.of(DELIVERED, CANCELLED);
+
+  private static final List<OrderState> NON_TERMINAL_STATES =
+          Collections.unmodifiableList(Arrays.stream(values()).filter(s -> !s.isTerminal()).collect(toList()));
+
+  public boolean isTerminal() {
+    return TERMINAL_STATES.contains(this);
+  }
+
+  /**
+   * The states an order can sit in while still awaiting work, in lifecycle order.
+   */
+  public static List<OrderState> nonTerminalStates() {
+    return NON_TERMINAL_STATES;
+  }
 }

--- a/ftgo-flyway/src/main/resources/db/migration/V3__add_order_created_time.sql
+++ b/ftgo-flyway/src/main/resources/db/migration/V3__add_order_created_time.sql
@@ -1,0 +1,10 @@
+use ftgo;
+
+-- Time an order entered the APPROVED state, used for SLA aging.
+ALTER TABLE orders ADD COLUMN created_time DATETIME NULL;
+
+UPDATE orders
+SET created_time = COALESCE(accept_time, preparing_time, ready_for_pickup_time, picked_up_time, delivered_time)
+WHERE created_time IS NULL;
+
+CREATE INDEX idx_orders_state_created_time ON orders (order_state, created_time);

--- a/ftgo-order-service-api/src/main/java/net/chrisrichardson/ftgo/orderservice/api/web/SlaBreachReport.java
+++ b/ftgo-order-service-api/src/main/java/net/chrisrichardson/ftgo/orderservice/api/web/SlaBreachReport.java
@@ -1,0 +1,40 @@
+package net.chrisrichardson.ftgo.orderservice.api.web;
+
+import java.util.List;
+import java.util.Map;
+
+public class SlaBreachReport {
+
+  private int totalBreaches;
+  private Map<String, Integer> breachCountsByState;
+  private Map<String, Integer> thresholdMinutesByState;
+  private List<SlaBreachedOrder> breaches;
+
+  private SlaBreachReport() {
+  }
+
+  public SlaBreachReport(Map<String, Integer> breachCountsByState,
+                         Map<String, Integer> thresholdMinutesByState,
+                         List<SlaBreachedOrder> breaches) {
+    this.breachCountsByState = breachCountsByState;
+    this.thresholdMinutesByState = thresholdMinutesByState;
+    this.breaches = breaches;
+    this.totalBreaches = breaches.size();
+  }
+
+  public int getTotalBreaches() {
+    return totalBreaches;
+  }
+
+  public Map<String, Integer> getBreachCountsByState() {
+    return breachCountsByState;
+  }
+
+  public Map<String, Integer> getThresholdMinutesByState() {
+    return thresholdMinutesByState;
+  }
+
+  public List<SlaBreachedOrder> getBreaches() {
+    return breaches;
+  }
+}

--- a/ftgo-order-service-api/src/main/java/net/chrisrichardson/ftgo/orderservice/api/web/SlaBreachedOrder.java
+++ b/ftgo-order-service-api/src/main/java/net/chrisrichardson/ftgo/orderservice/api/web/SlaBreachedOrder.java
@@ -1,0 +1,56 @@
+package net.chrisrichardson.ftgo.orderservice.api.web;
+
+import java.time.LocalDateTime;
+
+public class SlaBreachedOrder {
+
+  private Long orderId;
+  private String state;
+  private String restaurantName;
+  private LocalDateTime stateEnteredAt;
+  private long ageMinutes;
+  private int thresholdMinutes;
+  private long minutesOverSla;
+
+  private SlaBreachedOrder() {
+  }
+
+  public SlaBreachedOrder(Long orderId, String state, String restaurantName, LocalDateTime stateEnteredAt,
+                          long ageMinutes, int thresholdMinutes) {
+    this.orderId = orderId;
+    this.state = state;
+    this.restaurantName = restaurantName;
+    this.stateEnteredAt = stateEnteredAt;
+    this.ageMinutes = ageMinutes;
+    this.thresholdMinutes = thresholdMinutes;
+    this.minutesOverSla = ageMinutes - thresholdMinutes;
+  }
+
+  public Long getOrderId() {
+    return orderId;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public String getRestaurantName() {
+    return restaurantName;
+  }
+
+  public LocalDateTime getStateEnteredAt() {
+    return stateEnteredAt;
+  }
+
+  public long getAgeMinutes() {
+    return ageMinutes;
+  }
+
+  public int getThresholdMinutes() {
+    return thresholdMinutes;
+  }
+
+  public long getMinutesOverSla() {
+    return minutesOverSla;
+  }
+}

--- a/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/OrderConfiguration.java
+++ b/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/OrderConfiguration.java
@@ -5,13 +5,16 @@ import net.chrisrichardson.ftgo.consumerservice.domain.ConsumerService;
 import net.chrisrichardson.ftgo.domain.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import java.time.Clock;
 import java.util.Optional;
 
 @Configuration
+@EnableConfigurationProperties(SlaProperties.class)
 @Import(DomainConfiguration.class)
 public class OrderConfiguration {
   // TODO move to framework
@@ -33,6 +36,16 @@ public class OrderConfiguration {
             consumerService,
             courierRepository,
             courierAssignmentStrategy);
+  }
+
+  @Bean
+  public Clock slaClock() {
+    return Clock.systemDefaultZone();
+  }
+
+  @Bean
+  public SlaBreachService slaBreachService(OrderRepository orderRepository, SlaProperties slaProperties, Clock slaClock) {
+    return new SlaBreachService(orderRepository, slaProperties, slaClock);
   }
 
   @Bean

--- a/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/SlaBreachService.java
+++ b/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/SlaBreachService.java
@@ -1,0 +1,81 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import net.chrisrichardson.ftgo.domain.Order;
+import net.chrisrichardson.ftgo.domain.OrderRepository;
+import net.chrisrichardson.ftgo.domain.OrderState;
+import net.chrisrichardson.ftgo.orderservice.api.web.SlaBreachReport;
+import net.chrisrichardson.ftgo.orderservice.api.web.SlaBreachedOrder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Finds orders that have been sitting in a non-terminal state longer than the configured SLA.
+ */
+@Transactional(readOnly = true)
+public class SlaBreachService {
+
+  private final OrderRepository orderRepository;
+  private final SlaProperties slaProperties;
+  private final Clock clock;
+
+  public SlaBreachService(OrderRepository orderRepository, SlaProperties slaProperties, Clock clock) {
+    this.orderRepository = orderRepository;
+    this.slaProperties = slaProperties;
+    this.clock = clock;
+  }
+
+  public SlaBreachReport findBreaches() {
+    return findBreaches(OrderState.nonTerminalStates());
+  }
+
+  public SlaBreachReport findBreaches(OrderState orderState) {
+    if (orderState.isTerminal()) {
+      throw new TerminalOrderStateException(orderState);
+    }
+    return findBreaches(Collections.singletonList(orderState));
+  }
+
+  private SlaBreachReport findBreaches(List<OrderState> states) {
+    LocalDateTime now = LocalDateTime.now(clock);
+
+    Map<String, Integer> counts = new LinkedHashMap<>();
+    Map<String, Integer> thresholds = new LinkedHashMap<>();
+    for (OrderState state : states) {
+      counts.put(state.name(), 0);
+      thresholds.put(state.name(), slaProperties.thresholdMinutesFor(state));
+    }
+
+    List<SlaBreachedOrder> breaches = new ArrayList<>();
+    for (Order order : orderRepository.findAllByOrderStateIn(states)) {
+      OrderState state = order.getOrderState();
+      LocalDateTime stateEnteredAt = order.getStateEnteredTime();
+      if (stateEnteredAt == null) {
+        continue;
+      }
+      int thresholdMinutes = slaProperties.thresholdMinutesFor(state);
+      long ageMinutes = Duration.between(stateEnteredAt, now).toMinutes();
+      if (ageMinutes <= thresholdMinutes) {
+        continue;
+      }
+      breaches.add(new SlaBreachedOrder(order.getId(),
+              state.name(),
+              order.getRestaurant() == null ? null : order.getRestaurant().getName(),
+              stateEnteredAt,
+              ageMinutes,
+              thresholdMinutes));
+      counts.merge(state.name(), 1, Integer::sum);
+    }
+
+    breaches.sort((a, b) -> Long.compare(b.getAgeMinutes(), a.getAgeMinutes()));
+
+    return new SlaBreachReport(counts, thresholds, breaches);
+  }
+}

--- a/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/SlaProperties.java
+++ b/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/SlaProperties.java
@@ -34,9 +34,11 @@ public class SlaProperties {
   }
 
   public void setStateThresholdMinutes(Map<OrderState, Integer> stateThresholdMinutes) {
-    this.stateThresholdMinutes = stateThresholdMinutes == null
-            ? new EnumMap<>(OrderState.class)
-            : new EnumMap<>(stateThresholdMinutes);
+    Map<OrderState, Integer> copy = new EnumMap<>(OrderState.class);
+    if (stateThresholdMinutes != null) {
+      copy.putAll(stateThresholdMinutes);
+    }
+    this.stateThresholdMinutes = copy;
   }
 
   public int thresholdMinutesFor(OrderState orderState) {

--- a/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/SlaProperties.java
+++ b/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/SlaProperties.java
@@ -1,0 +1,54 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import net.chrisrichardson.ftgo.domain.OrderState;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Delivery SLA thresholds, in minutes, for orders sitting in a non-terminal state.
+ * Configured with {@code ftgo.sla.default-threshold-minutes} and
+ * {@code ftgo.sla.state-threshold-minutes.<STATE>}.
+ */
+@ConfigurationProperties(prefix = "ftgo.sla")
+public class SlaProperties {
+
+  public static final int DEFAULT_THRESHOLD_MINUTES = 30;
+
+  private int defaultThresholdMinutes = DEFAULT_THRESHOLD_MINUTES;
+
+  private Map<OrderState, Integer> stateThresholdMinutes = new EnumMap<>(OrderState.class);
+
+  public int getDefaultThresholdMinutes() {
+    return defaultThresholdMinutes;
+  }
+
+  public void setDefaultThresholdMinutes(int defaultThresholdMinutes) {
+    this.defaultThresholdMinutes = defaultThresholdMinutes;
+  }
+
+  public Map<OrderState, Integer> getStateThresholdMinutes() {
+    return stateThresholdMinutes;
+  }
+
+  public void setStateThresholdMinutes(Map<OrderState, Integer> stateThresholdMinutes) {
+    this.stateThresholdMinutes = stateThresholdMinutes == null
+            ? new EnumMap<>(OrderState.class)
+            : new EnumMap<>(stateThresholdMinutes);
+  }
+
+  public int thresholdMinutesFor(OrderState orderState) {
+    Integer override = stateThresholdMinutes.get(orderState);
+    return override == null ? defaultThresholdMinutes : override;
+  }
+
+  public Map<String, Integer> effectiveThresholdMinutes() {
+    Map<String, Integer> thresholds = new LinkedHashMap<>();
+    for (OrderState state : OrderState.nonTerminalStates()) {
+      thresholds.put(state.name(), thresholdMinutesFor(state));
+    }
+    return thresholds;
+  }
+}

--- a/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/TerminalOrderStateException.java
+++ b/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/domain/TerminalOrderStateException.java
@@ -1,0 +1,10 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import net.chrisrichardson.ftgo.domain.OrderState;
+
+public class TerminalOrderStateException extends RuntimeException {
+
+  public TerminalOrderStateException(OrderState orderState) {
+    super("Order state " + orderState + " is terminal and has no SLA");
+  }
+}

--- a/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/web/SlaBreachController.java
+++ b/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/web/SlaBreachController.java
@@ -1,0 +1,43 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import net.chrisrichardson.ftgo.domain.OrderState;
+import net.chrisrichardson.ftgo.orderservice.api.web.SlaBreachReport;
+import net.chrisrichardson.ftgo.orderservice.domain.SlaBreachService;
+import net.chrisrichardson.ftgo.orderservice.domain.TerminalOrderStateException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/orders/sla-breaches")
+public class SlaBreachController {
+
+  private final SlaBreachService slaBreachService;
+
+  public SlaBreachController(SlaBreachService slaBreachService) {
+    this.slaBreachService = slaBreachService;
+  }
+
+  @RequestMapping(method = RequestMethod.GET)
+  public ResponseEntity<SlaBreachReport> getSlaBreaches(@RequestParam(required = false) String state) {
+    if (state == null) {
+      return new ResponseEntity<>(slaBreachService.findBreaches(), HttpStatus.OK);
+    }
+
+    OrderState orderState;
+    try {
+      orderState = OrderState.valueOf(state.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+
+    try {
+      return new ResponseEntity<>(slaBreachService.findBreaches(orderState), HttpStatus.OK);
+    } catch (TerminalOrderStateException e) {
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+  }
+}

--- a/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/web/SlaBreachController.java
+++ b/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/web/SlaBreachController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Locale;
+
 @RestController
 @RequestMapping(path = "/orders/sla-breaches")
 public class SlaBreachController {
@@ -29,7 +31,7 @@ public class SlaBreachController {
 
     OrderState orderState;
     try {
-      orderState = OrderState.valueOf(state.toUpperCase());
+      orderState = OrderState.valueOf(state.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/OrderDetailsMother.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/OrderDetailsMother.java
@@ -4,6 +4,7 @@ import net.chrisrichardson.ftgo.common.Money;
 import net.chrisrichardson.ftgo.domain.*;
 import net.chrisrichardson.ftgo.orderservice.web.MenuItemIdAndQuantity;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,6 +32,31 @@ public class OrderDetailsMother {
   public static Order CHICKEN_VINDALOO_ORDER = makeAjantaOrder();
 
   public static final OrderState CHICKEN_VINDALOO_ORDER_STATE = OrderState.APPROVED;
+
+  public static Order makeOrderInState(long orderId, OrderState orderState) {
+    Order order = new Order(CONSUMER_ID, RestaurantMother.AJANTA_RESTAURANT, chickenVindalooLineItems());
+    order.setId(orderId);
+    if (orderState == OrderState.APPROVED)
+      return order;
+    if (orderState == OrderState.CANCELLED) {
+      order.cancel();
+      return order;
+    }
+    order.acceptTicket(LocalDateTime.now().plusMinutes(30));
+    if (orderState == OrderState.ACCEPTED)
+      return order;
+    order.notePreparing();
+    if (orderState == OrderState.PREPARING)
+      return order;
+    order.noteReadyForPickup();
+    if (orderState == OrderState.READY_FOR_PICKUP)
+      return order;
+    order.notePickedUp();
+    if (orderState == OrderState.PICKED_UP)
+      return order;
+    order.noteDelivered();
+    return order;
+  }
 
   private static Order makeAjantaOrder() {
     Order order = new Order(CONSUMER_ID, new Restaurant(AJANTA_ID, "", new RestaurantMenu(Collections.emptyList())), chickenVindalooLineItems());

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/SlaBreachServiceTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/SlaBreachServiceTest.java
@@ -32,18 +32,20 @@ public class SlaBreachServiceTest {
 
   private OrderRepository orderRepository;
   private SlaProperties slaProperties;
-  private LocalDateTime baseTime;
 
   @Before
   public void setUp() {
     orderRepository = mock(OrderRepository.class);
     slaProperties = new SlaProperties();
     slaProperties.setDefaultThresholdMinutes(30);
-    baseTime = LocalDateTime.now();
   }
 
-  private SlaBreachService serviceAt(long minutesAfterBase) {
-    Clock clock = Clock.fixed(baseTime.plusMinutes(minutesAfterBase).atZone(ZONE).toInstant(), ZONE);
+  /**
+   * A service whose clock reads the given number of minutes from now. Call it after building the
+   * orders under test so that their state-entry timestamps are never later than the clock's origin.
+   */
+  private SlaBreachService serviceAt(long minutesFromNow) {
+    Clock clock = Clock.fixed(LocalDateTime.now().plusMinutes(minutesFromNow).atZone(ZONE).toInstant(), ZONE);
     return new SlaBreachService(orderRepository, slaProperties, clock);
   }
 
@@ -126,8 +128,7 @@ public class SlaBreachServiceTest {
     slaProperties.setStateThresholdMinutes(Collections.singletonMap(OrderState.APPROVED, 1));
     repositoryContains(older, newer);
 
-    Clock clock = Clock.fixed(baseTime.plusMinutes(60).atZone(ZONE).toInstant(), ZONE);
-    SlaBreachReport report = new SlaBreachService(orderRepository, slaProperties, clock).findBreaches();
+    SlaBreachReport report = serviceAt(60).findBreaches();
 
     assertEquals(2, report.getTotalBreaches());
     assertTrue(report.getBreaches().get(0).getAgeMinutes() >= report.getBreaches().get(1).getAgeMinutes());

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/SlaBreachServiceTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/domain/SlaBreachServiceTest.java
@@ -1,0 +1,156 @@
+package net.chrisrichardson.ftgo.orderservice.domain;
+
+import net.chrisrichardson.ftgo.domain.Order;
+import net.chrisrichardson.ftgo.domain.OrderRepository;
+import net.chrisrichardson.ftgo.domain.OrderState;
+import net.chrisrichardson.ftgo.orderservice.api.web.SlaBreachReport;
+import net.chrisrichardson.ftgo.orderservice.api.web.SlaBreachedOrder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static net.chrisrichardson.ftgo.orderservice.OrderDetailsMother.makeOrderInState;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SlaBreachServiceTest {
+
+  private static final ZoneId ZONE = ZoneId.systemDefault();
+
+  private OrderRepository orderRepository;
+  private SlaProperties slaProperties;
+  private LocalDateTime baseTime;
+
+  @Before
+  public void setUp() {
+    orderRepository = mock(OrderRepository.class);
+    slaProperties = new SlaProperties();
+    slaProperties.setDefaultThresholdMinutes(30);
+    baseTime = LocalDateTime.now();
+  }
+
+  private SlaBreachService serviceAt(long minutesAfterBase) {
+    Clock clock = Clock.fixed(baseTime.plusMinutes(minutesAfterBase).atZone(ZONE).toInstant(), ZONE);
+    return new SlaBreachService(orderRepository, slaProperties, clock);
+  }
+
+  private void repositoryContains(Order... orders) {
+    List<Order> all = Arrays.asList(orders);
+    when(orderRepository.findAllByOrderStateIn(any(Collection.class))).thenAnswer(invocation -> {
+      Collection<OrderState> states = (Collection<OrderState>) invocation.getArguments()[0];
+      return all.stream().filter(o -> states.contains(o.getOrderState())).collect(toList());
+    });
+  }
+
+  @Test
+  public void shouldFlagOrderOlderThanThreshold() {
+    Order order = makeOrderInState(1L, OrderState.PREPARING);
+    repositoryContains(order);
+
+    SlaBreachReport report = serviceAt(45).findBreaches();
+
+    assertEquals(1, report.getTotalBreaches());
+    SlaBreachedOrder breach = report.getBreaches().get(0);
+    assertEquals(Long.valueOf(1L), breach.getOrderId());
+    assertEquals(OrderState.PREPARING.name(), breach.getState());
+    assertEquals(45, breach.getAgeMinutes());
+    assertEquals(30, breach.getThresholdMinutes());
+    assertEquals(15, breach.getMinutesOverSla());
+    assertEquals(Integer.valueOf(1), report.getBreachCountsByState().get(OrderState.PREPARING.name()));
+  }
+
+  @Test
+  public void shouldNotFlagOrderAtExactlyTheThreshold() {
+    repositoryContains(makeOrderInState(1L, OrderState.PREPARING));
+
+    SlaBreachReport report = serviceAt(30).findBreaches();
+
+    assertEquals(0, report.getTotalBreaches());
+    assertEquals(emptyList(), report.getBreaches());
+  }
+
+  @Test
+  public void shouldPreferPerStateThresholdOverDefault() {
+    slaProperties.setStateThresholdMinutes(Collections.singletonMap(OrderState.APPROVED, 10));
+    repositoryContains(makeOrderInState(1L, OrderState.APPROVED), makeOrderInState(2L, OrderState.PREPARING));
+
+    SlaBreachReport report = serviceAt(20).findBreaches();
+
+    assertEquals(1, report.getTotalBreaches());
+    assertEquals(Long.valueOf(1L), report.getBreaches().get(0).getOrderId());
+    assertEquals(10, report.getBreaches().get(0).getThresholdMinutes());
+    assertEquals(Integer.valueOf(10), report.getThresholdMinutesByState().get(OrderState.APPROVED.name()));
+    assertEquals(Integer.valueOf(30), report.getThresholdMinutesByState().get(OrderState.PREPARING.name()));
+  }
+
+  @Test
+  public void shouldExcludeTerminalOrders() {
+    repositoryContains(makeOrderInState(1L, OrderState.DELIVERED), makeOrderInState(2L, OrderState.CANCELLED));
+
+    SlaBreachReport report = serviceAt(500).findBreaches();
+
+    assertEquals(0, report.getTotalBreaches());
+    assertTrue(report.getBreachCountsByState().keySet().stream().noneMatch(s ->
+            s.equals(OrderState.DELIVERED.name()) || s.equals(OrderState.CANCELLED.name())));
+  }
+
+  @Test
+  public void shouldZeroFillCountsForEveryNonTerminalState() {
+    repositoryContains();
+
+    SlaBreachReport report = serviceAt(500).findBreaches();
+
+    assertEquals(0, report.getTotalBreaches());
+    assertEquals(OrderState.nonTerminalStates().stream().map(Enum::name).collect(toList()),
+            report.getBreachCountsByState().keySet().stream().collect(toList()));
+    assertTrue(report.getBreachCountsByState().values().stream().allMatch(c -> c == 0));
+  }
+
+  @Test
+  public void shouldSortBreachesByAgeDescending() {
+    Order older = makeOrderInState(1L, OrderState.APPROVED);
+    Order newer = makeOrderInState(2L, OrderState.APPROVED);
+    slaProperties.setStateThresholdMinutes(Collections.singletonMap(OrderState.APPROVED, 1));
+    repositoryContains(older, newer);
+
+    Clock clock = Clock.fixed(baseTime.plusMinutes(60).atZone(ZONE).toInstant(), ZONE);
+    SlaBreachReport report = new SlaBreachService(orderRepository, slaProperties, clock).findBreaches();
+
+    assertEquals(2, report.getTotalBreaches());
+    assertTrue(report.getBreaches().get(0).getAgeMinutes() >= report.getBreaches().get(1).getAgeMinutes());
+  }
+
+  @Test
+  public void shouldFilterByStateAndCountOnlyThatState() {
+    repositoryContains(makeOrderInState(1L, OrderState.APPROVED), makeOrderInState(2L, OrderState.PREPARING));
+
+    SlaBreachReport report = serviceAt(45).findBreaches(OrderState.PREPARING);
+
+    assertEquals(1, report.getTotalBreaches());
+    assertEquals(Collections.singleton(OrderState.PREPARING.name()), report.getBreachCountsByState().keySet());
+    assertEquals(Long.valueOf(2L), report.getBreaches().get(0).getOrderId());
+  }
+
+  @Test
+  public void shouldRejectTerminalStateFilter() {
+    repositoryContains();
+    try {
+      serviceAt(45).findBreaches(OrderState.DELIVERED);
+      fail("expected TerminalOrderStateException");
+    } catch (TerminalOrderStateException expected) {
+    }
+  }
+}

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/SlaBreachControllerTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/SlaBreachControllerTest.java
@@ -1,0 +1,113 @@
+package net.chrisrichardson.ftgo.orderservice.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import net.chrisrichardson.ftgo.common.MoneyModule;
+import net.chrisrichardson.ftgo.domain.OrderState;
+import net.chrisrichardson.ftgo.orderservice.api.web.SlaBreachReport;
+import net.chrisrichardson.ftgo.orderservice.api.web.SlaBreachedOrder;
+import net.chrisrichardson.ftgo.orderservice.domain.SlaBreachService;
+import net.chrisrichardson.ftgo.orderservice.domain.TerminalOrderStateException;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SlaBreachControllerTest {
+
+  private SlaBreachService slaBreachService;
+  private SlaBreachController slaBreachController;
+
+  @Before
+  public void setUp() {
+    slaBreachService = mock(SlaBreachService.class);
+    slaBreachController = new SlaBreachController(slaBreachService);
+  }
+
+  @Test
+  public void shouldReturnBreachesAndCounts() {
+    when(slaBreachService.findBreaches()).thenReturn(report());
+
+    given().
+            standaloneSetup(configureControllers(slaBreachController)).
+    when().
+            get("/orders/sla-breaches").
+    then().
+            statusCode(200).
+            body("totalBreaches", equalTo(1)).
+            body("breachCountsByState.PREPARING", equalTo(1)).
+            body("thresholdMinutesByState.PREPARING", equalTo(30)).
+            body("breaches[0].orderId", equalTo(7)).
+            body("breaches[0].state", equalTo(OrderState.PREPARING.name())).
+            body("breaches[0].ageMinutes", equalTo(45)).
+            body("breaches[0].minutesOverSla", equalTo(15))
+    ;
+  }
+
+  @Test
+  public void shouldFilterByState() {
+    when(slaBreachService.findBreaches(OrderState.PREPARING)).thenReturn(report());
+
+    given().
+            standaloneSetup(configureControllers(slaBreachController)).
+    when().
+            get("/orders/sla-breaches?state=preparing").
+    then().
+            statusCode(200).
+            body("totalBreaches", equalTo(1))
+    ;
+  }
+
+  @Test
+  public void shouldRejectUnknownState() {
+    given().
+            standaloneSetup(configureControllers(slaBreachController)).
+    when().
+            get("/orders/sla-breaches?state=NOT_A_STATE").
+    then().
+            statusCode(400)
+    ;
+  }
+
+  @Test
+  public void shouldRejectTerminalState() {
+    when(slaBreachService.findBreaches(OrderState.DELIVERED)).thenThrow(new TerminalOrderStateException(OrderState.DELIVERED));
+
+    given().
+            standaloneSetup(configureControllers(slaBreachController)).
+    when().
+            get("/orders/sla-breaches?state=DELIVERED").
+    then().
+            statusCode(400)
+    ;
+  }
+
+  private SlaBreachReport report() {
+    Map<String, Integer> counts = new LinkedHashMap<>();
+    counts.put(OrderState.PREPARING.name(), 1);
+    Map<String, Integer> thresholds = new LinkedHashMap<>();
+    thresholds.put(OrderState.PREPARING.name(), 30);
+    SlaBreachedOrder breach = new SlaBreachedOrder(7L, OrderState.PREPARING.name(), "Ajanta",
+            LocalDateTime.now().minusMinutes(45), 45, 30);
+    return new SlaBreachReport(counts, thresholds, Collections.singletonList(breach));
+  }
+
+  private StandaloneMockMvcBuilder configureControllers(Object... controllers) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new MoneyModule());
+    objectMapper.registerModule(new JavaTimeModule());
+    MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter(objectMapper);
+    return MockMvcBuilders.standaloneSetup(controllers).setMessageConverters(converter);
+  }
+}


### PR DESCRIPTION
## Summary

Implements STORY-1 of the "Delivery SLA breach visibility" breakdown (EPIC-1): backend detection of orders sitting too long in a non-terminal state, plus the API the dashboard view (STORY-3) and leadership summary panel (STORY-4) will consume.

**Story — STORY-1: SLA breach detection service and REST endpoint.** Acceptance criteria covered here:
- thresholds are config-driven (`ftgo.sla.default-threshold-minutes`, `ftgo.sla.state-threshold-minutes.<STATE>`), no code change to retune;
- breach = non-terminal state and time-in-state strictly greater than that state's threshold;
- `GET /orders/sla-breaches` returns total, zero-filled per-state counts, effective thresholds, and the breaching orders sorted worst-first;
- `?state=PREPARING` filters; unknown or terminal state → 400;
- clock is injectable, so tests are deterministic.

Threshold resolution and the breach predicate:

```java
int threshold = slaProperties.thresholdMinutesFor(state);   // per-state override, else default
long age = Duration.between(order.getStateEnteredTime(), LocalDateTime.now(clock)).toMinutes();
boolean breaching = !state.isTerminal() && age > threshold; // exactly at threshold is not a breach
```

Aging needs a timestamp for the `APPROVED` state, which the model did not have: `Order` now records `createdTime` at construction and exposes `getStateEnteredTime()`, which maps the current state to its transition timestamp (`createdTime`/`acceptTime`/`preparingTime`/`readyForPickupTime`/`pickedUpTime`). Migration `V3__add_order_created_time.sql` adds the column and coalesces later timestamps into it for existing rows; the full backfill/verification of legacy rows is STORY-2.

`SlaBreachController` is mapped at the exact path `/orders/sla-breaches` so it takes precedence over `OrderController`'s `/orders/{orderId}` template. Orders with a null state-entry timestamp (pre-migration rows) are skipped rather than reported as infinitely aged.

Example response:

```json
{
  "totalBreaches": 1,
  "breachCountsByState": {"APPROVED": 0, "ACCEPTED": 0, "PREPARING": 1, "READY_FOR_PICKUP": 0, "PICKED_UP": 0},
  "thresholdMinutesByState": {"APPROVED": 10, "ACCEPTED": 15, "PREPARING": 30, "READY_FOR_PICKUP": 15, "PICKED_UP": 45},
  "breaches": [
    {"orderId": 7, "state": "PREPARING", "restaurantName": "Ajanta",
     "stateEnteredAt": "2026-08-26T14:05:00", "ageMinutes": 45, "thresholdMinutes": 30, "minutesOverSla": 15}
  ]
}
```

## Testing

`./gradlew :ftgo-order-service:build :ftgo-domain:build :ftgo-order-service-api:build` — green (JDK 8). 12 new unit tests: `SlaBreachServiceTest` (threshold boundary, per-state override precedence, terminal exclusion, zero-filled counts, sort order, state filter, terminal-filter rejection) and `SlaBreachControllerTest` (payload shape, filter, 400s).

`./gradlew build` still fails in `:ftgo-end-to-end-tests-common` on an unresolvable `io.eventuate.util:eventuate-util-test:0.1.0.RELEASE` (jcenter is gone); reproduced on a clean checkout of `main`, so it is preexisting and unrelated.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/571d893525e74e1c8a2c88a4ae2ae8fd
Requested by: @achalc
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/301?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->