### PR TITLE
Fix: Deeply nested json in jackson-databind

### DIFF
--- a/ftgo-application/build.gradle
+++ b/ftgo-application/build.gradle
@@ -1,5 +1,13 @@
 apply plugin: FtgoServicePlugin
 
+ext['jackson.version'] = '2.12.7'
+
+dependencyManagement {
+    dependencies {
+        dependency 'com.fasterxml.jackson.core:jackson-databind:2.12.7.1'
+    }
+}
+
 dependencies {
     compile project(":ftgo-consumer-service")
     compile project(":ftgo-order-service")

--- a/ftgo-application/build.gradle
+++ b/ftgo-application/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: FtgoServicePlugin
 
-ext['jackson.version'] = '2.12.7'
+ext['jackson.version'] = '2.17.3'
 
 dependencyManagement {
     dependencies {
-        dependency 'com.fasterxml.jackson.core:jackson-databind:2.12.7.1'
+        dependency 'com.fasterxml.jackson.core:jackson-databind:2.17.3'
     }
 }
 

--- a/ftgo-application/build.gradle
+++ b/ftgo-application/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: FtgoServicePlugin
 
-ext['jackson.version'] = '2.17.3'
+ext['jackson.version'] = '2.18.9'
 
 dependencyManagement {
     dependencies {
-        dependency 'com.fasterxml.jackson.core:jackson-databind:2.17.3'
+        dependency 'com.fasterxml.jackson.core:jackson-databind:2.18.9'
     }
 }
 

--- a/ftgo-common/build.gradle
+++ b/ftgo-common/build.gradle
@@ -5,10 +5,10 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.17.3'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.17.3'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.18.9'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.9'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.3"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.9"
 
     compile 'mysql:mysql-connector-java:8.0.33'
 

--- a/ftgo-common/build.gradle
+++ b/ftgo-common/build.gradle
@@ -5,10 +5,10 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.7'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.7'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.7'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.7.1'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.7"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.7"
 
     compile 'mysql:mysql-connector-java:8.0.33'
 

--- a/ftgo-common/build.gradle
+++ b/ftgo-common/build.gradle
@@ -5,10 +5,10 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.7'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.7.1'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.17.3'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.17.3'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.7"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.3"
 
     compile 'mysql:mysql-connector-java:8.0.33'
 

--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/MoneyModule.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/MoneyModule.java
@@ -30,7 +30,7 @@ public class MoneyModule extends SimpleModule {
         else
           return new Money(str);
       } else
-        throw ctxt.mappingException(getValueClass());
+        return (Money) ctxt.handleUnexpectedToken(getValueType(ctxt), jp);
     }
   }
 


### PR DESCRIPTION
## Summary
**Finding:** Deeply nested json in jackson-databind (CVE-2020-36518, GHSA-57j2-w4cx-62h2) — repo `COG-GTM/ftgo-monolith`.

**Fix approach:** upgrade jackson from the vulnerable 2.9.x line to 2.18.9 (the nearest release with no open advisories) and pin it past Spring Boot 2.0.3's BOM, which would otherwise manage jackson back down to 2.9.6.

- `ftgo-common/build.gradle`: `jackson-core` / `jackson-databind` / `jackson-datatype-jsr310` 2.9.7 → 2.18.9
- `ftgo-application/build.gradle`: `ext['jackson.version'] = '2.18.9'` + explicit `dependencyManagement` entry for `jackson-databind:2.18.9` so the deployable jar doesn't fall back to the BOM-managed 2.9.6 (`dependencyInsight` confirms all modules resolve `2.9.6 -> 2.18.9`)
- `MoneyModule.MoneyDeserializer`: replace `ctxt.mappingException(...)` (removed API) with `ctxt.handleUnexpectedToken(getValueType(ctxt), jp)`

Note: initial bump targeted 2.17.3, which still carries open Snyk advisories (e.g. SNYK-JAVA-COMFASTERXMLJACKSONCORE-19256875, fixed range starts at 2.18.9); 2.18.9 has no direct vulnerabilities per Snyk and keeps the Java 8 baseline.

Runtime-verified with MySQL running: the assembled app boots (`Started FtgoApplicationMain`) and `@RequestBody` JSON deserialization on `POST /consumers` is exercised through jackson 2.18.9 (well-formed JSON reaches the persistence layer; malformed JSON returns the expected `JsonParseException`-backed error).

Link to Devin session: https://app.devin.ai/sessions/8b55ca827c434b7aae8f15842ab1f49a
Open in Devin Desktop: https://app.devin.ai/desktop/session/8b55ca827c434b7aae8f15842ab1f49a?variant=devin
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/302?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->