### PR TITLE
Fix: Unauthenticated API tracking endpoints expose logged client IPs, user agents, and query strings

### DIFF
--- a/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingController.java
+++ b/ftgo-common/src/main/java/net/chrisrichardson/ftgo/common/tracking/ApiTrackingController.java
@@ -1,5 +1,6 @@
 package net.chrisrichardson.ftgo.common.tracking;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping(path = "/api/tracking")
+@ConditionalOnProperty(name = "ftgo.api-tracking.endpoints.enabled", havingValue = "true")
 public class ApiTrackingController {
 
   private final ApiRequestLogRepository apiRequestLogRepository;


### PR DESCRIPTION
## Summary
**Finding:** Unauthenticated API tracking endpoints expose logged client IPs, user agents, and query strings — repo `COG-GTM/ftgo-monolith` (NS-compliance gap: no privilege boundary between anonymous callers and persisted request metadata).

**Fix approach:** gate `ApiTrackingController` behind an opt-in property so the metadata-exposure endpoints are disabled by default and only registered when a deployment explicitly enables them.

`ApiTrackingInterceptor` persists every request's `remoteAddr`, `User-Agent`, URI, and full query string to `api_request_log`, and `ApiTrackingController` served that store at `/api/tracking/**` with no authentication (the repo has no Spring Security). The change:

```java
@RestController
@RequestMapping(path = "/api/tracking")
+@ConditionalOnProperty(name = "ftgo.api-tracking.endpoints.enabled", havingValue = "true")
public class ApiTrackingController {
```

Request tracking itself (interceptor + persistence) is unchanged; only the read endpoints become opt-in for trusted internal deployments.

Runtime-verified with MySQL running: by default `GET /api/tracking/logs` now returns 404 while business endpoints keep working; with `FTGO_API_TRACKING_ENDPOINTS_ENABLED=true` the endpoints are registered and return the logged metadata as before.

Link to Devin session: https://app.devin.ai/sessions/8b55ca827c434b7aae8f15842ab1f49a
Open in Devin Desktop: https://app.devin.ai/desktop/session/8b55ca827c434b7aae8f15842ab1f49a?variant=devin
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/304?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->