### PR TITLE
Fix: Application image built on an EOL, non-digest-pinned base image (openjdk:8u171-jre-alpine)

### DIFF
--- a/ftgo-application/Dockerfile
+++ b/ftgo-application/Dockerfile
@@ -1,5 +1,7 @@
-FROM openjdk:8u171-jre-alpine
-RUN apk --no-cache add curl
+# Maintained Java 8 runtime (Eclipse Temurin), pinned by digest so the image
+# contents are integrity-fixed. Refresh the tag+digest regularly to pick up
+# security patches.
+FROM eclipse-temurin:8u462-b08-jre-alpine@sha256:963a365705214a3ab2880de348027864b3a2afa4e0f44f62c466c6b8d652e8b2
 CMD java ${JAVA_OPTS} -jar ftgo-application.jar
-HEALTHCHECK --start-period=30s --interval=5s CMD curl -f http://localhost:8080/actuator/health || exit 1
+HEALTHCHECK --start-period=30s --interval=5s CMD wget -q -O /dev/null http://localhost:8080/actuator/health || exit 1
 COPY build/libs/ftgo-application.jar .


### PR DESCRIPTION
## Summary

Security fix for COG-GTM/ftgo-monolith: the deployed `ftgo-application` image was built `FROM openjdk:8u171-jre-alpine`, an end-of-life tag whose JRE/Alpine userland carries years of unpatched CVEs, referenced only by a mutable tag (no digest), plus an unpinned `apk add curl`. The fix moves the image to a maintained Eclipse Temurin 8 JRE base pinned by digest and removes the extra package install.

```diff
-FROM openjdk:8u171-jre-alpine
-RUN apk --no-cache add curl
+FROM eclipse-temurin:8u462-b08-jre-alpine@sha256:963a365705214a3ab2880de348027864b3a2afa4e0f44f62c466c6b8d652e8b2
 CMD java ${JAVA_OPTS} -jar ftgo-application.jar
-HEALTHCHECK ... CMD curl -f http://localhost:8080/actuator/health || exit 1
+HEALTHCHECK ... CMD wget -q -O /dev/null http://localhost:8080/actuator/health || exit 1
```

Temurin 8u462 keeps the runtime on Java 8 (the project targets `sourceCompatibility = '1.8'`), and the digest makes the base layer integrity-fixed so a registry re-push cannot silently change what is built. `curl` is dropped entirely: the healthcheck uses busybox `wget`, already present in the Alpine base, which still fails non-zero on a non-200 response.

Verified locally: `docker run` on the pinned digest reports `openjdk version "1.8.0_462"` and a working busybox `wget`, and `docker build` of the Dockerfile succeeds.

Refresh the tag+digest periodically to pick up future patches.


Link to Devin session: https://app.devin.ai/sessions/7feb5b0c7c854425b7a53c2964fcb12f
Open in Devin Desktop: https://app.devin.ai/desktop/session/7feb5b0c7c854425b7a53c2964fcb12f?variant=devin
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/305?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->