### PR TITLE
Fix: Ungated bulk enumeration of a consumer's full order history by arbitrary consumerId

### DIFF
--- a/ftgo-application/build.gradle
+++ b/ftgo-application/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     compile "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+    compile "org.springframework.boot:spring-boot-starter-security:$springBootVersion"
 
     runtime 'mysql:mysql-connector-java:8.0.33'
 

--- a/ftgo-application/src/main/java/net/chrisrichardson/ftgo/security/SecurityConfig.java
+++ b/ftgo-application/src/main/java/net/chrisrichardson/ftgo/security/SecurityConfig.java
@@ -1,0 +1,53 @@
+package net.chrisrichardson.ftgo.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+  @Value("${ftgo.security.operations.username}")
+  private String operationsUsername;
+
+  @Value("${ftgo.security.operations.password}")
+  private String operationsPassword;
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+  @Bean
+  @Override
+  public UserDetailsService userDetailsService() {
+    return new InMemoryUserDetailsManager(
+            User.withUsername(operationsUsername)
+                    .password(passwordEncoder().encode(operationsPassword))
+                    .roles("OPERATIONS")
+                    .build());
+  }
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http.csrf().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .authorizeRequests()
+            .antMatchers(HttpMethod.GET, "/orders").authenticated()
+            .anyRequest().permitAll()
+            .and()
+            .httpBasic();
+  }
+}

--- a/ftgo-application/src/main/resources/application.properties
+++ b/ftgo-application/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo?useSSL=false
 spring.datasource.username=mysqluser
 spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+ftgo.security.operations.username=${FTGO_OPERATIONS_USERNAME:operations}
+ftgo.security.operations.password=${FTGO_OPERATIONS_PASSWORD:operations-secret}

--- a/ftgo-end-to-end-tests-common/src/main/java/net/chrisrichardson/ftgo/endtoendtests/common/AbstractEndToEndTests.java
+++ b/ftgo-end-to-end-tests-common/src/main/java/net/chrisrichardson/ftgo/endtoendtests/common/AbstractEndToEndTests.java
@@ -76,6 +76,16 @@ public abstract class AbstractEndToEndTests {
     return baseUrl(getApplicationPort(), "orders", pathElements);
   }
 
+  private String operationsUsername() {
+    String username = System.getenv("FTGO_OPERATIONS_USERNAME");
+    return username == null ? "operations" : username;
+  }
+
+  private String operationsPassword() {
+    String password = System.getenv("FTGO_OPERATIONS_PASSWORD");
+    return password == null ? "operations-secret" : password;
+  }
+
   @BeforeClass
   public static void initialize() {
     objectMapper.registerModule(new MoneyModule());
@@ -281,6 +291,7 @@ public abstract class AbstractEndToEndTests {
   private void verifyOrderHistoryUpdated(int orderId, int consumerId) {
     Eventually.eventually(String.format("verifyOrderHistoryUpdated %s", orderId), () -> {
       String state = given().
+              auth().preemptive().basic(operationsUsername(), operationsPassword()).
               when().
               get(orderBaseUrl() + "?consumerId=" + consumerId).
               then().

--- a/ftgo-order-service/build.gradle
+++ b/ftgo-order-service/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
     compile "io.micrometer:micrometer-registry-prometheus:$micrometerVersion"
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+    compile "org.springframework.security:spring-security-core:$springSecurityVersion"
     compile 'javax.el:javax.el-api:2.2.5'
 
     testCompile "org.springframework.boot:spring-boot-starter-test:$springBootVersion"

--- a/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/web/OrderController.java
+++ b/ftgo-order-service/src/main/java/net/chrisrichardson/ftgo/orderservice/web/OrderController.java
@@ -9,6 +9,7 @@ import net.chrisrichardson.ftgo.orderservice.domain.OrderNotFoundException;
 import net.chrisrichardson.ftgo.orderservice.domain.OrderService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -49,13 +50,26 @@ public class OrderController {
   }
 
   @RequestMapping(method = RequestMethod.GET)
-  public ResponseEntity<List<GetOrderResponse>> getOrders(@RequestParam long consumerId) {
+  public ResponseEntity<List<GetOrderResponse>> getOrders(@RequestParam long consumerId, Authentication authentication) {
+    if (!canAccessConsumerOrders(authentication, consumerId)) {
+      return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+    }
+
     List<GetOrderResponse> orders = orderRepository.findAllByConsumerId(consumerId)
             .stream()
             .map(this::makeGetOrderResponse)
             .collect(Collectors.toList());
 
     return new ResponseEntity<>(orders, HttpStatus.OK);
+  }
+
+  private boolean canAccessConsumerOrders(Authentication authentication, long consumerId) {
+    if (authentication == null || !authentication.isAuthenticated()) {
+      return false;
+    }
+    boolean isOperations = authentication.getAuthorities().stream()
+            .anyMatch(a -> "ROLE_OPERATIONS".equals(a.getAuthority()));
+    return isOperations || Long.toString(consumerId).equals(authentication.getName());
   }
 
   private GetOrderResponse makeGetOrderResponse(Order order) {

--- a/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/OrderControllerTest.java
+++ b/ftgo-order-service/src/test/java/net/chrisrichardson/ftgo/orderservice/web/OrderControllerTest.java
@@ -8,17 +8,25 @@ import net.chrisrichardson.ftgo.orderservice.domain.OrderService;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static net.chrisrichardson.ftgo.orderservice.OrderDetailsMother.CHICKEN_VINDALOO_ORDER;
 import static net.chrisrichardson.ftgo.orderservice.OrderDetailsMother.CHICKEN_VINDALOO_ORDER_TOTAL;
+import static net.chrisrichardson.ftgo.orderservice.OrderDetailsMother.CONSUMER_ID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class OrderControllerTest {
 
@@ -62,6 +70,53 @@ public class OrderControllerTest {
     then().
             statusCode(404)
     ;
+  }
+
+  @Test
+  public void shouldReturnOrdersForConsumerWhenOperationsRole() throws Exception {
+    when(orderRepository.findAllByConsumerId(CONSUMER_ID)).thenReturn(Collections.singletonList(CHICKEN_VINDALOO_ORDER));
+
+    configureControllers(orderController).build()
+            .perform(get("/orders").param("consumerId", Long.toString(CONSUMER_ID))
+                    .principal(operationsAuthentication()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].orderId").value((int) OrderDetailsMother.ORDER_ID));
+  }
+
+  @Test
+  public void shouldReturnOrdersForMatchingConsumerPrincipal() throws Exception {
+    when(orderRepository.findAllByConsumerId(CONSUMER_ID)).thenReturn(Collections.singletonList(CHICKEN_VINDALOO_ORDER));
+
+    configureControllers(orderController).build()
+            .perform(get("/orders").param("consumerId", Long.toString(CONSUMER_ID))
+                    .principal(consumerAuthentication(CONSUMER_ID)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].orderId").value((int) OrderDetailsMother.ORDER_ID));
+  }
+
+  @Test
+  public void shouldRejectOrderHistoryRequestForOtherConsumer() throws Exception {
+    configureControllers(orderController).build()
+            .perform(get("/orders").param("consumerId", Long.toString(CONSUMER_ID))
+                    .principal(consumerAuthentication(CONSUMER_ID + 1)))
+            .andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void shouldRejectUnauthenticatedOrderHistoryRequest() throws Exception {
+    configureControllers(orderController).build()
+            .perform(get("/orders").param("consumerId", Long.toString(CONSUMER_ID)))
+            .andExpect(status().isForbidden());
+  }
+
+  private Authentication operationsAuthentication() {
+    return new UsernamePasswordAuthenticationToken("operations", "",
+            AuthorityUtils.createAuthorityList("ROLE_OPERATIONS"));
+  }
+
+  private Authentication consumerAuthentication(long consumerId) {
+    return new UsernamePasswordAuthenticationToken(Long.toString(consumerId), "",
+            AuthorityUtils.createAuthorityList("ROLE_CONSUMER"));
   }
 
   private StandaloneMockMvcBuilder configureControllers(Object... controllers) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ deployUrl=file:///Users/cer/.m2/testdeploy
 eventuateMavenRepoUrl=https://dl.bintray.com/eventuateio-oss/eventuate-maven-release,file:///Users/cer/.m2/testdeploy
 
 springBootVersion=2.0.3.RELEASE
+springSecurityVersion=5.0.6.RELEASE
 restAssuredVersion=2.9.0
 springDependencyManagementPluginVersion=1.0.3.RELEASE
 eventuateUtilVersion=0.1.0.RELEASE


### PR DESCRIPTION
## Summary
Remediates the code-scan finding **"Ungated bulk enumeration of a consumer's full order history by arbitrary consumerId"** in `COG-GTM/ftgo-monolith` (`OrderController.getOrders`, `GET /orders?consumerId=`). Fix approach: require authentication on the order-history list endpoint and bind the `consumerId` filter to the authenticated principal (or an approved operations role), so a caller can no longer enumerate arbitrary consumers' order history.

Changes:
- New `SecurityConfig` (`ftgo-application`, stateless HTTP Basic via `spring-boot-starter-security`): `GET /orders` (the bulk list route) now requires authentication; all other routes keep their existing behavior (`permitAll`). Credentials for the approved operations account come from `ftgo.security.operations.username/password` (env-overridable via `FTGO_OPERATIONS_USERNAME`/`FTGO_OPERATIONS_PASSWORD`).
- `OrderController.getOrders(consumerId, authentication)` now enforces:
  ```
  allowed = hasAuthority(ROLE_OPERATIONS) || authentication.getName() == consumerId
  otherwise -> 403 FORBIDDEN
  ```
  so the caller-supplied `consumerId` is tied to the authenticated principal instead of being fully attacker-controlled.
- End-to-end test `verifyOrderHistoryUpdated` authenticates with the operations account (test coverage preserved, now exercising the gated path).
- New unit tests: operations role → 200, matching consumer principal → 200, mismatched consumer → 403, unauthenticated → 403.

**Data-flow change / NS-terms note:** this changes the access path for protected user data (consumer order history) — the bulk read route is no longer reachable unauthenticated and each read is tied to an authenticated principal, addressing the NS-terms gated/approved-access obligation for protected user data. Every request through the endpoint continues to be recorded by the existing `ApiTrackingInterceptor` audit log, now attributable to an authenticated caller. No retention, deletion, or classification values were changed. If the NS-terms access path is expected to be enforced by an external gateway in front of `/orders` instead, that is a policy decision for compliance to confirm; this PR enforces it in-repo.

Verified locally (Java 8): `:ftgo-order-service:test` passes (6/6), app boots against the Docker MySQL — unauthenticated `GET /orders?consumerId=1` → 401, operations-authenticated → 200, other endpoints (e.g. `POST /consumers`, static UI) unaffected.

Link to Devin session: https://app.devin.ai/sessions/e6866cbf03c04114be02c4089a3f43bb
Open in Devin Desktop: https://app.devin.ai/desktop/session/e6866cbf03c04114be02c4089a3f43bb?variant=devin
Requested by: @WesternConcrete
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/306?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/ftgo-monolith/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/ftgo-monolith/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->